### PR TITLE
Inject query options in context

### DIFF
--- a/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
@@ -105,8 +105,8 @@ describe("generateReactQueryComponents", () => {
        * Get all the pets
        */
       export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
-          ...queryOptions,
-          ...options
+          ...options,
+          ...queryOptions
       }); };
       "
     `);
@@ -217,8 +217,8 @@ describe("generateReactQueryComponents", () => {
        * Get all the pets
        */
       export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
-          ...queryOptions,
-          ...options
+          ...options,
+          ...queryOptions
       }); };
       "
     `);
@@ -333,8 +333,8 @@ describe("generateReactQueryComponents", () => {
        * Get all the pets
        */
       export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
-          ...queryOptions,
-          ...options
+          ...options,
+          ...queryOptions
       }); };
       "
     `);
@@ -420,8 +420,8 @@ describe("generateReactQueryComponents", () => {
        * Get all the pets
        */
       export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
-          ...queryOptions,
-          ...options
+          ...options,
+          ...queryOptions
       }); };
       "
     `);

--- a/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
@@ -104,7 +104,7 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
@@ -216,7 +216,7 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
@@ -332,7 +332,7 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
@@ -419,7 +419,7 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -485,10 +485,10 @@ const createQueryHook = ({
                       f.createObjectLiteralExpression(
                         [
                           f.createSpreadAssignment(
-                            f.createIdentifier("queryOptions")
+                            f.createIdentifier("options")
                           ),
                           f.createSpreadAssignment(
-                            f.createIdentifier("options")
+                            f.createIdentifier("queryOptions")
                           ),
                         ],
                         true

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -438,7 +438,7 @@ const createQueryHook = ({
                         f.createCallExpression(
                           f.createIdentifier(contextHookName),
                           undefined,
-                          []
+                          [f.createIdentifier("options")]
                         )
                       ),
                     ],

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -1,7 +1,7 @@
 import { pascal } from "case";
 
 export const getContext = (prefix: string) =>
-  `import type { QueryKey } from "react-query";
+  `import type { QueryKey, UseQueryOptions } from "react-query";
   
   export type ${pascal(prefix)}Context = {
     fetcherOptions: {
@@ -36,9 +36,9 @@ export const getContext = (prefix: string) =>
    TQueryFnData = unknown,
    TError = unknown,
    TData = TQueryFnData,
-   TQueryKey extends reactQuery.QueryKey = reactQuery.QueryKey
+   TQueryKey extends QueryKey = QueryKey
  >(
-   queryOptions?: Omit<reactQuery.UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'>
+   queryOptions?: Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'>
  ): ${pascal(prefix)}Context {
     return {
       fetcherOptions: {},

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -29,8 +29,17 @@ export const getContext = (prefix: string) =>
   
   /**
    * Context injected into every react-query hook wrappers
+   * 
+   * @param queryOptions options from the useQuery wrapper
    */
-  export const use${pascal(prefix)}Context = (): ${pascal(prefix)}Context => {
+   export function use${pascal(prefix)}Context<
+   TQueryFnData = unknown,
+   TError = unknown,
+   TData = TQueryFnData,
+   TQueryKey extends reactQuery.QueryKey = reactQuery.QueryKey
+ >(
+   queryOptions?: Omit<reactQuery.UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'>
+ ): ${pascal(prefix)}Context {
     return {
       fetcherOptions: {},
       queryOptions: {},


### PR DESCRIPTION
## Problem

In a nextJS application with the current setup:

```ts
// xatabaseContext.ts
import { useSession } from 'next-auth/react';

/**
 * Context injected into every react-query hook wrappers
 */
export function useXatabaseContext(): XatabaseContext {
  const { data } = useSession();
  return {
    queryOptions: {
      enabled: Boolean(data?.accessToken) // <- We want to skip the query if the auth is not ready
    },
   };
}
```

But somebody have some custom logic to skip a query:

```tsx
export const MyComp = (props: { branch: string }) => {
  const { data } = useGetBranchDetails(
    ['my-key'],
    {
      pathParams: {
        branch: props.branch
      }
    },
    {
      enabled: branch // <- I don't want to trigger the query if the `branch` is not set!
    }
  );
};
```

But because, in the generated hook we have this:
```ts

export const useGetBranchDetails = (
  queryKey: reactQuery.QueryKey,
  variables: GetBranchDetailsVariables,
  options?: Omit<
    reactQuery.UseQueryOptions<GetBranchDetailsResponse, Responses.SimpleError, GetBranchDetailsResponse>,
    'queryKey' | 'queryFn'
  >
) => {
  const { fetcherOptions, queryOptions, queryKeyFn } = useXatabaseContext(options);
  return reactQuery.useQuery<GetBranchDetailsResponse, Responses.SimpleError, GetBranchDetailsResponse>(
    queryKeyFn(queryKey),
    () => fetchGetBranchDetails({ ...fetcherOptions, ...variables }),
    {
      ...queryOptions
      ...options, // <- the problem is here!
    }
  );
};
```

So, sneakily, I'm bypassing the auth flow by setting `enabled` options 🤯 

## Solution

First, let's invert the `...queryOptions` and `...options` so we can enforce the logic!

Second, because I don't want to shift the problem, let's pass the `options` to the `useXatabaseContext` so we can consolidate the option!

In the user land, we can now adjust our context to take `queryOptions.enabled` in consideration.
```diff
/**
  * Context injected into every react-query hook wrappers
+ *
+ * @param queryOptions options from the useQuery wrapper
  */
-export const useXatabaseContext = (): XatabaseContext => {
+export function useXatabaseContext<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends reactQuery.QueryKey = reactQuery.QueryKey
+>(
+  queryOptions?: Omit<reactQuery.UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'>
+): XatabaseContext {
@@ -40,11 +49,11 @@ export const useXatabaseContext = (): XatabaseContext => {
       workspace
     },
     queryOptions: {
-      enabled: Boolean(data?.accessToken)
+      enabled: Boolean(data?.accessToken) && (queryOptions?.enabled ?? true)
     },
   };
-};
+}
```

And voilà! We can now skip a query without bypassing the auth flow! 🎉 