### PR TITLE
Generate react-query key manager

### DIFF
--- a/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
@@ -104,10 +104,16 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
+
+      export type QueryOperation = {
+          path: \\"/pets\\";
+          operationId: \\"listPets\\";
+          variables: ListPetsVariables;
+      };
       "
     `);
   });
@@ -216,10 +222,16 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
+
+      export type QueryOperation = {
+          path: \\"/pets\\";
+          operationId: \\"listPets\\";
+          variables: ListPetsVariables;
+      };
       "
     `);
   });
@@ -332,10 +344,16 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
+
+      export type QueryOperation = {
+          path: \\"/pets\\";
+          operationId: \\"listPets\\";
+          variables: ListPetsVariables;
+      };
       "
     `);
   });
@@ -419,10 +437,16 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = (queryKey: reactQuery.QueryKey, variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn(queryKey), () => fetchListPets({ ...fetcherOptions, ...variables }), {
+      export const useListPets = (variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, undefined, ListPetsResponse>, \\"queryKey\\" | \\"queryFn\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, undefined, ListPetsResponse>(queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }), () => fetchListPets({ ...fetcherOptions, ...variables }), {
           ...options,
           ...queryOptions
       }); };
+
+      export type QueryOperation = {
+          path: \\"/pets\\";
+          operationId: \\"listPets\\";
+          variables: ListPetsVariables;
+      };
       "
     `);
   });
@@ -542,6 +566,8 @@ describe("generateReactQueryComponents", () => {
           const { fetcherOptions } = usePetstoreContext();
           return reactQuery.useMutation<string, AddPetError, AddPetVariables>((variables: AddPetVariables) => fetchAddPet({ ...fetcherOptions, ...variables }), options);
       };
+
+      export type QueryOperation = never;
       "
     `);
   });
@@ -662,6 +688,8 @@ describe("generateReactQueryComponents", () => {
           const { fetcherOptions } = usePetstoreContext();
           return reactQuery.useMutation<string, AddPetError, AddPetVariables>((variables: AddPetVariables) => fetchAddPet({ ...fetcherOptions, ...variables }), options);
       };
+
+      export type QueryOperation = never;
       "
     `);
   });
@@ -782,6 +810,8 @@ describe("generateReactQueryComponents", () => {
           const { fetcherOptions } = usePetstoreContext();
           return reactQuery.useMutation<string, AddPetError, AddPetVariables>((variables: AddPetVariables) => fetchAddPet({ ...fetcherOptions, ...variables }), options);
       };
+
+      export type QueryOperation = never;
       "
     `);
   });
@@ -881,6 +911,8 @@ describe("generateReactQueryComponents", () => {
           const { fetcherOptions } = usePetstoreContext();
           return reactQuery.useMutation<string, undefined, UpdatePetVariables>((variables: UpdatePetVariables) => fetchUpdatePet({ ...fetcherOptions, ...variables }), options);
       };
+
+      export type QueryOperation = never;
       "
     `);
   });

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -142,9 +142,14 @@ export const generateReactQueryComponents = async (
         }
 
         if (component === "useQuery") {
+          const queryBuilderType = compactNodes([
+            pathParamsType,
+            queryParamsType,
+            requestBodyType,
+          ]);
+
           keyManagerItems.push([
             operationId,
-
             f.createArrowFunction(
               undefined,
               undefined,
@@ -155,14 +160,15 @@ export const generateReactQueryComponents = async (
                   undefined,
                   f.createIdentifier("variables"),
                   undefined,
-                  f.createIntersectionTypeNode(
-                    compactNodes([
-                      pathParamsType,
-                      queryParamsType,
-                      requestBodyType,
-                    ])
-                  ),
-                  undefined
+                  queryBuilderType.length > 0
+                    ? f.createIntersectionTypeNode(queryBuilderType)
+                    : f.createTypeReferenceNode("Record", [
+                        f.createTypeReferenceNode("string"),
+                        f.createTypeReferenceNode("never"),
+                      ]),
+                  queryBuilderType.length === 0
+                    ? f.createObjectLiteralExpression([])
+                    : undefined
                 ),
               ],
               undefined,
@@ -629,12 +635,12 @@ const createReactQueryImport = () =>
 
 // TODO: Properly type this
 function compactNodes(nodes: any[]): any[] {
-  // TODO: Remove empty {}
   return nodes.filter(
     (node) =>
       node !== undefined &&
       node.kind !== ts.SyntaxKind.UndefinedKeyword &&
-      node.kind !== ts.SyntaxKind.NullKeyword
+      node.kind !== ts.SyntaxKind.NullKeyword &&
+      hasProperties(node)
   );
 }
 

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -482,8 +482,7 @@ const createQueryHook = ({
                               "operationId",
                               f.createStringLiteral(operationId)
                             ),
-                            f.createPropertyAssignment(
-                              "variables",
+                            f.createShorthandPropertyAssignment(
                               f.createIdentifier("variables")
                             ),
                           ]),

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -73,6 +73,7 @@ export const generateReactQueryComponents = async (
   const contextTypeName = `${c.pascal(filenamePrefix)}Context`;
   const contextHookName = `use${c.pascal(filenamePrefix)}Context`;
   const nodes: ts.Node[] = [];
+  const keyManagerItems: [string, ts.Expression][] = [];
 
   const fetcherFilename = formatFilename(filenamePrefix + "-fetcher");
   const contextFilename = formatFilename(filenamePrefix + "-context");
@@ -140,6 +141,49 @@ export const generateReactQueryComponents = async (
           Valid options: "useMutate", "useQuery"`);
         }
 
+        if (component === "useQuery") {
+          keyManagerItems.push([
+            operationId,
+
+            f.createArrowFunction(
+              undefined,
+              undefined,
+              [
+                f.createParameterDeclaration(
+                  undefined,
+                  undefined,
+                  undefined,
+                  f.createIdentifier("variables"),
+                  undefined,
+                  f.createIntersectionTypeNode(
+                    compactNodes([
+                      pathParamsType,
+                      queryParamsType,
+                      requestBodyType,
+                    ])
+                  ),
+                  undefined
+                ),
+              ],
+              undefined,
+              f.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              f.createArrayLiteralExpression([
+                f.createStringLiteral(operationId),
+                f.createSpreadElement(
+                  f.createCallExpression(
+                    f.createPropertyAccessExpression(
+                      f.createIdentifier("Object"),
+                      f.createIdentifier("values")
+                    ),
+                    undefined,
+                    [f.createIdentifier("variables")]
+                  )
+                ),
+              ])
+            ),
+          ]);
+        }
+
         nodes.push(
           ...createOperationFetcherFnNodes({
             dataType,
@@ -178,6 +222,25 @@ export const generateReactQueryComponents = async (
     }
   );
 
+  const queryKeyManager = f.createVariableStatement(
+    [f.createModifier(ts.SyntaxKind.ExportKeyword)],
+    f.createVariableDeclarationList(
+      [
+        f.createVariableDeclaration(
+          f.createIdentifier("queryKeyManager"),
+          undefined,
+          undefined,
+          f.createObjectLiteralExpression(
+            keyManagerItems.map(([key, node]) =>
+              f.createPropertyAssignment(key, node)
+            )
+          )
+        ),
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
   await context.writeFile(
     filename + ".ts",
     printNodes([
@@ -190,6 +253,7 @@ export const generateReactQueryComponents = async (
       createNamedImport(fetcherFn, `./${fetcherFilename}`),
       ...getUsedImports(nodes, config.schemasFiles),
       ...nodes,
+      queryKeyManager,
     ])
   );
 };
@@ -538,3 +602,13 @@ const createReactQueryImport = () =>
     f.createStringLiteral("react-query"),
     undefined
   );
+
+function compactNodes(nodes: ts.TypeNode[]): readonly ts.TypeNode[] {
+  // TODO: Remove empty {}
+  return nodes.filter(
+    (node) =>
+      node !== undefined &&
+      node.kind !== ts.SyntaxKind.UndefinedKeyword &&
+      node.kind !== ts.SyntaxKind.NullKeyword
+  );
+}

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -1,4 +1,4 @@
-import ts, { factory as f } from "typescript";
+import ts, { factory as f, SyntaxKind } from "typescript";
 import * as c from "case";
 
 import { ConfigBase, Context } from "./types";
@@ -86,7 +86,10 @@ export const generateReactQueryComponents = async (
   }
 
   if (!context.existsFile(`${contextFilename}.ts`)) {
-    context.writeFile(`${contextFilename}.ts`, getContext(filenamePrefix));
+    context.writeFile(
+      `${contextFilename}.ts`,
+      getContext(filenamePrefix, filename)
+    );
   }
 
   // Generate `useQuery` & `useMutation`
@@ -142,12 +145,6 @@ export const generateReactQueryComponents = async (
         }
 
         if (component === "useQuery") {
-          const queryBuilderType = compactNodes([
-            pathParamsType,
-            queryParamsType,
-            requestBodyType,
-          ]);
-
           keyManagerItems.push([
             operationId,
             f.createArrowFunction(
@@ -160,31 +157,67 @@ export const generateReactQueryComponents = async (
                   undefined,
                   f.createIdentifier("variables"),
                   undefined,
-                  queryBuilderType.length > 0
-                    ? f.createIntersectionTypeNode(queryBuilderType)
-                    : f.createTypeReferenceNode("Record", [
-                        f.createTypeReferenceNode("string"),
-                        f.createTypeReferenceNode("never"),
-                      ]),
-                  queryBuilderType.length === 0
-                    ? f.createObjectLiteralExpression([])
-                    : undefined
+                  f.createTypeReferenceNode(f.createIdentifier("Omit"), [
+                    variablesType,
+                    f.createTypeOperatorNode(
+                      SyntaxKind.KeyOfKeyword,
+                      f.createIndexedAccessTypeNode(
+                        f.createTypeReferenceNode(
+                          f.createIdentifier(contextTypeName)
+                        ),
+                        f.createLiteralTypeNode(
+                          f.createStringLiteral("fetcherOptions")
+                        )
+                      )
+                    ),
+                  ]),
+                  undefined
                 ),
               ],
               undefined,
               f.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
               f.createArrayLiteralExpression([
+                f.createSpreadElement(
+                  compactNodes([pathParamsType]).length > 0
+                    ? f.createCallExpression(
+                        f.createPropertyAccessExpression(
+                          f.createIdentifier("Object"),
+                          f.createIdentifier("values")
+                        ),
+                        undefined,
+                        [
+                          f.createPropertyAccessExpression(
+                            f.createIdentifier("variables"),
+                            f.createIdentifier("pathParams")
+                          ),
+                        ]
+                      )
+                    : f.createArrayLiteralExpression([])
+                ),
                 f.createStringLiteral(operationId),
                 f.createSpreadElement(
-                  f.createCallExpression(
-                    f.createPropertyAccessExpression(
-                      f.createIdentifier("Object"),
-                      f.createIdentifier("values")
-                    ),
-                    undefined,
-                    [f.createIdentifier("variables")]
-                  )
+                  compactNodes([queryParamsType]).length > 0
+                    ? f.createCallExpression(
+                        f.createPropertyAccessExpression(
+                          f.createIdentifier("Object"),
+                          f.createIdentifier("values")
+                        ),
+                        undefined,
+                        [
+                          f.createPropertyAccessExpression(
+                            f.createIdentifier("variables"),
+                            f.createIdentifier("queryParams")
+                          ),
+                        ]
+                      )
+                    : f.createArrayLiteralExpression([])
                 ),
+                compactNodes([requestBodyType]).length > 0
+                  ? f.createPropertyAccessExpression(
+                      f.createIdentifier("variables"),
+                      f.createIdentifier("body")
+                    )
+                  : f.createArrayLiteralExpression([]),
               ])
             ),
           ]);
@@ -527,29 +560,10 @@ const createQueryHook = ({
                               f.createIdentifier(operationId)
                             ),
                             undefined,
-                            [
-                              f.createObjectLiteralExpression(
-                                compactNodes([
-                                  hasProperties(requestBodyType)
-                                    ? f.createSpreadAssignment(
-                                        f.createPropertyAccessExpression(
-                                          f.createIdentifier("variables"),
-                                          f.createIdentifier("body")
-                                        )
-                                      )
-                                    : undefined,
-                                  hasProperties(pathParamsType)
-                                    ? f.createSpreadAssignment(
-                                        f.createPropertyAccessExpression(
-                                          f.createIdentifier("variables"),
-                                          f.createIdentifier("pathParams")
-                                        )
-                                      )
-                                    : undefined,
-                                ])
-                              ),
-                            ]
+                            [f.createIdentifier("variables")]
                           ),
+                          f.createStringLiteral(operationId),
+                          f.createIdentifier("variables"),
                         ]
                       ),
                       f.createArrowFunction(

--- a/plugins/typescript/src/index.ts
+++ b/plugins/typescript/src/index.ts
@@ -6,3 +6,4 @@ export { generateFetchers } from "./generators/generateFetchers";
 // Utils
 export { renameComponent } from "./utils/renameComponent";
 export { forceReactQueryComponent } from "./utils/forceReactQueryComponent";
+export { addPathParam } from "./utils/addPathParam";

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -55,10 +55,4 @@ export const getContext = (prefix: string, componentsFile: string) =>
       },
     };
   };
-
-  type KeyManager<T extends keyof typeof queryKeyManager> = NonNullable<Parameters<typeof queryKeyManager[T]>[0]> & {
-    pathParams?: Record<string, string>;
-    queryParams?: Record<string, string>;
-    body?: unknown;
-  };
   `;

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -2,7 +2,7 @@ import { pascal } from "case";
 
 export const getContext = (prefix: string, componentsFile: string) =>
   `import type { QueryKey, UseQueryOptions } from "react-query";
-  import { queryKeyManager } from './${componentsFile}';
+  import { Operation } from './${componentsFile}';
   
   export type ${pascal(prefix)}Context = {
     fetcherOptions: {
@@ -25,11 +25,7 @@ export const getContext = (prefix: string, componentsFile: string) =>
     /**
      * Query key middleware.
      */
-    queryKeyFn: <T extends keyof typeof queryKeyManager>(
-      queryKey: reactQuery.QueryKey,
-      operation: T,
-      variables: KeyManager<T>
-    ) => reactQuery.QueryKey;
+    queryKeyFn: (operation: Operation) => reactQuery.QueryKey;
   };
   
   /**
@@ -48,7 +44,15 @@ export const getContext = (prefix: string, componentsFile: string) =>
     return {
       fetcherOptions: {},
       queryOptions: {},
-      queryKeyFn: queryKey => queryKey,
+      queryKeyFn: queryKey => {
+        switch (operation.operationId) {
+          default: {
+            const { pathParams, queryParams, body } = operation.variables;
+
+            return [operation, pathParams, queryParams, body];
+          }
+        }
+      },
     };
   };
 

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -2,7 +2,7 @@ import { pascal } from "case";
 
 export const getContext = (prefix: string, componentsFile: string) =>
   `import type { QueryKey, UseQueryOptions } from "react-query";
-  import { Operation } from './${componentsFile}';
+  import { QueryOperation } from './${componentsFile}';
   
   export type ${pascal(prefix)}Context = {
     fetcherOptions: {
@@ -25,7 +25,7 @@ export const getContext = (prefix: string, componentsFile: string) =>
     /**
      * Query key middleware.
      */
-    queryKeyFn: (operation: Operation) => reactQuery.QueryKey;
+    queryKeyFn: (operation: QueryOperation) => reactQuery.QueryKey;
   };
   
   /**

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -1,7 +1,8 @@
 import { pascal } from "case";
 
-export const getContext = (prefix: string) =>
+export const getContext = (prefix: string, componentsFile: string) =>
   `import type { QueryKey, UseQueryOptions } from "react-query";
+  import { queryKeyManager } from './${componentsFile}';
   
   export type ${pascal(prefix)}Context = {
     fetcherOptions: {
@@ -24,7 +25,11 @@ export const getContext = (prefix: string) =>
     /**
      * Query key middleware.
      */
-    queryKeyFn: (queryKey: QueryKey) => QueryKey;
+    queryKeyFn: <T extends keyof typeof queryKeyManager>(
+      queryKey: reactQuery.QueryKey,
+      operation: T,
+      variables: KeyManager<T>
+    ) => reactQuery.QueryKey;
   };
   
   /**
@@ -45,5 +50,11 @@ export const getContext = (prefix: string) =>
       queryOptions: {},
       queryKeyFn: queryKey => queryKey,
     };
+  };
+
+  type KeyManager<T extends keyof typeof queryKeyManager> = NonNullable<Parameters<typeof queryKeyManager[T]>[0]> & {
+    pathParams?: Record<string, string>;
+    queryParams?: Record<string, string>;
+    body?: unknown;
   };
   `;

--- a/plugins/typescript/src/utils/addPathParam.test.ts
+++ b/plugins/typescript/src/utils/addPathParam.test.ts
@@ -1,0 +1,179 @@
+import { OpenAPIObject } from "openapi3-ts";
+import { addPathParam } from "./addPathParam";
+
+describe("addPathParam", () => {
+  const openAPIDocument: OpenAPIObject = {
+    openapi: "3.0.0",
+    info: {
+      title: "petshop",
+      version: "1.0.0",
+    },
+    paths: {
+      "/pets": {
+        get: {
+          operationId: "listPets",
+          description: "Get all the pets",
+          responses: {
+            "200": {
+              description: "pet response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "array",
+                    items: {
+                      $ref: "#/components/schemas/Pet",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it("should add a new path param not required", async () => {
+    const openAPIDocumentWithPathParam = addPathParam({
+      openAPIDocument,
+      pathParam: "breed",
+      required: false,
+    });
+
+    expect(openAPIDocumentWithPathParam).toMatchInlineSnapshot(`
+      Object {
+        "info": Object {
+          "title": "petshop",
+          "version": "1.0.0",
+        },
+        "openapi": "3.0.0",
+        "paths": Object {
+          "/pets": Object {
+            "get": Object {
+              "description": "Get all the pets",
+              "operationId": "listPets",
+              "responses": Object {
+                "200": Object {
+                  "content": Object {
+                    "application/json": Object {
+                      "schema": Object {
+                        "items": Object {
+                          "$ref": "#/components/schemas/Pet",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "description": "pet response",
+                },
+              },
+            },
+            "parameters": Array [
+              Object {
+                "in": "path",
+                "name": "breed",
+                "required": false,
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            ],
+          },
+        },
+      }
+    `);
+  });
+
+  it("should add a new path param required", async () => {
+    const openAPIDocumentWithPathParam = addPathParam({
+      openAPIDocument,
+      pathParam: "breed",
+      required: true,
+    });
+
+    expect(openAPIDocumentWithPathParam).toMatchInlineSnapshot(`
+      Object {
+        "info": Object {
+          "title": "petshop",
+          "version": "1.0.0",
+        },
+        "openapi": "3.0.0",
+        "paths": Object {
+          "/pets": Object {
+            "get": Object {
+              "description": "Get all the pets",
+              "operationId": "listPets",
+              "responses": Object {
+                "200": Object {
+                  "content": Object {
+                    "application/json": Object {
+                      "schema": Object {
+                        "items": Object {
+                          "$ref": "#/components/schemas/Pet",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "description": "pet response",
+                },
+              },
+            },
+            "parameters": Array [
+              Object {
+                "in": "path",
+                "name": "breed",
+                "required": true,
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            ],
+          },
+        },
+      }
+    `);
+  });
+
+  it("should add a new path param conditionally", async () => {
+    const openAPIDocumentWithPathParam = addPathParam({
+      openAPIDocument,
+      pathParam: "breed",
+      required: false,
+      condition: (key) => key !== "/pets",
+    });
+
+    expect(openAPIDocumentWithPathParam).toMatchInlineSnapshot(`
+      Object {
+        "info": Object {
+          "title": "petshop",
+          "version": "1.0.0",
+        },
+        "openapi": "3.0.0",
+        "paths": Object {
+          "/pets": Object {
+            "get": Object {
+              "description": "Get all the pets",
+              "operationId": "listPets",
+              "responses": Object {
+                "200": Object {
+                  "content": Object {
+                    "application/json": Object {
+                      "schema": Object {
+                        "items": Object {
+                          "$ref": "#/components/schemas/Pet",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "description": "pet response",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/plugins/typescript/src/utils/addPathParam.ts
+++ b/plugins/typescript/src/utils/addPathParam.ts
@@ -1,0 +1,48 @@
+import { mapValues } from "lodash";
+import { OpenAPIObject, PathItemObject } from "openapi3-ts";
+
+/**
+ * Util to rename an openAPI component name
+ */
+export const addPathParam = ({
+  openAPIDocument,
+  pathParam,
+  isRequired = false,
+  filter = () => true,
+}: {
+  /**
+   * The openAPI document to transform
+   */
+  openAPIDocument: OpenAPIObject;
+  /**
+   * Path param to inject in all requests
+   */
+  pathParam: string;
+  /**
+   * If the path param is required
+   * @default false
+   */
+  isRequired?: boolean;
+  filter?: (key: string, pathParam: PathItemObject) => boolean;
+}): OpenAPIObject => {
+  return {
+    ...openAPIDocument,
+    paths: mapValues(
+      openAPIDocument.paths,
+      (value: PathItemObject, key: string) => ({
+        ...value,
+        parameters: filter(key, value)
+          ? [
+              ...(value.parameters ?? []),
+              {
+                name: pathParam,
+                in: "path",
+                required: isRequired,
+                schema: { type: "string" },
+              },
+            ]
+          : value.parameters,
+      })
+    ),
+  };
+};

--- a/plugins/typescript/src/utils/addPathParam.ts
+++ b/plugins/typescript/src/utils/addPathParam.ts
@@ -2,13 +2,13 @@ import { mapValues } from "lodash";
 import { OpenAPIObject, PathItemObject } from "openapi3-ts";
 
 /**
- * Util to rename an openAPI component name
+ * Util to add a path param to an openAPI operation
  */
 export const addPathParam = ({
   openAPIDocument,
   pathParam,
-  isRequired = false,
-  filter = () => true,
+  required,
+  condition: filter = () => true,
 }: {
   /**
    * The openAPI document to transform
@@ -20,29 +20,32 @@ export const addPathParam = ({
   pathParam: string;
   /**
    * If the path param is required
-   * @default false
    */
-  isRequired?: boolean;
-  filter?: (key: string, pathParam: PathItemObject) => boolean;
+  required: boolean;
+  /**
+   * Condition to include/exclude the path param
+   */
+  condition?: (key: string, pathParam: PathItemObject) => boolean;
 }): OpenAPIObject => {
   return {
     ...openAPIDocument,
     paths: mapValues(
       openAPIDocument.paths,
-      (value: PathItemObject, key: string) => ({
-        ...value,
-        parameters: filter(key, value)
-          ? [
-              ...(value.parameters ?? []),
-              {
-                name: pathParam,
-                in: "path",
-                required: isRequired,
-                schema: { type: "string" },
-              },
-            ]
-          : value.parameters,
-      })
+      (value: PathItemObject, key: string) =>
+        filter(key, value)
+          ? {
+              ...value,
+              parameters: [
+                ...(value.parameters ?? []),
+                {
+                  name: pathParam,
+                  in: "path",
+                  required,
+                  schema: { type: "string" },
+                },
+              ],
+            }
+          : value
     ),
   };
 };


### PR DESCRIPTION
Adds a new ``queryKeyManager`` that hosts all the ``react-query`` keys built on-the-fly. 🪄 

Also adds a new ``util`` to inject ``queryParams`` into an OpenAPI spec from the config file.