### PR TITLE
fix: Remove the need of `qs` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow the steps, this will generate a configuration file for you (openapi-codeg
 
 You should have a bunch of types / components ready to be used.
 
-Note: The generated `{namespace}Fetcher.ts` assume a global `fetch` and the `qs` package, this is just a suggestion, you can do what ever you want on this file as soon as the types are compliant.
+Note: The generated `{namespace}Fetcher.ts` assume a global `fetch`, if you want to use this in a nodejs environment, please update this file (this is just a template)
 
 ## Philosophy
 

--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -14,8 +14,7 @@ export const getFetcher = ({
   contextPath?: string;
   baseUrl?: string;
 }) =>
-  `import qs from "qs";
-  ${
+  `${
     contextPath
       ? `import { ${pascal(prefix)}Context } from "./${contextPath}";`
       : `
@@ -88,10 +87,10 @@ export async function ${camel(prefix)}Fetch<
 
 const resolveUrl = (
   url: string,
-  queryParams: Record<string, unknown> = {},
+  queryParams: Record<string, string> = {},
   pathParams: Record<string, string> = {}
 ) => {
-  let query = qs.stringify(queryParams);
+  let query = new URLSearchParams(queryParams).toString();
   if (query) query = \`?\${query}\`;
   return url.replace(/\\{\\w*\\}/g, (key) => pathParams[key.slice(1, -1)]) + query;
 };


### PR DESCRIPTION
Remove the `qs` dependency in the fetcher template to ease the getting started.