### PR TITLE
fix: Fixed ServerErrorStatus, ClientErrorStatus not being imported as type

### DIFF
--- a/plugins/typescript/src/core/createNamedImport.ts
+++ b/plugins/typescript/src/core/createNamedImport.ts
@@ -5,17 +5,19 @@ import { factory as f } from "typescript";
  *
  * @param fnName functions to imports
  * @param filename path of the module
+ * @param isTypeOnly whether fnName are used as types only
  * @returns ts.Node of the import declaration
  */
 export const createNamedImport = (
   fnName: string | string[],
-  filename: string
+  filename: string,
+  isTypeOnly = false
 ) => {
   const fnNames = Array.isArray(fnName) ? fnName : [fnName];
   return f.createImportDeclaration(
     undefined,
     f.createImportClause(
-      false,
+      isTypeOnly,
       undefined,
       f.createNamedImports(
         fnNames.map((name) =>

--- a/plugins/typescript/src/core/getUsedImports.test.ts
+++ b/plugins/typescript/src/core/getUsedImports.test.ts
@@ -223,7 +223,7 @@ describe("getUsedImports", () => {
         .nodes.map(print)
         .join("\n")
     ).toMatchInlineSnapshot(
-      `"import { ClientErrorStatus } from \\"././utils\\";"`
+      `"import type { ClientErrorStatus } from \\"././utils\\";"`
     );
   });
 
@@ -253,7 +253,7 @@ describe("getUsedImports", () => {
         .nodes.map(print)
         .join("\n")
     ).toMatchInlineSnapshot(
-      `"import { ServerErrorStatus } from \\"././utils\\";"`
+      `"import type { ServerErrorStatus } from \\"././utils\\";"`
     );
   });
 
@@ -294,7 +294,7 @@ describe("getUsedImports", () => {
         .nodes.map(print)
         .join("\n")
     ).toMatchInlineSnapshot(
-      `"import { ServerErrorStatus, ClientErrorStatus } from \\"././utils\\";"`
+      `"import type { ServerErrorStatus, ClientErrorStatus } from \\"././utils\\";"`
     );
   });
 });

--- a/plugins/typescript/src/core/getUsedImports.ts
+++ b/plugins/typescript/src/core/getUsedImports.ts
@@ -89,7 +89,7 @@ export const getUsedImports = (
       if (i.type === "namespace") {
         return createNamespaceImport(i.namespace, `./${i.from}`);
       } else {
-        return createNamedImport(Array.from(i.imports.values()), `./${i.from}`);
+        return createNamedImport(Array.from(i.imports.values()), `./${i.from}`, true);
       }
     }),
   };

--- a/plugins/typescript/src/generators/generateFetchers.test.ts
+++ b/plugins/typescript/src/generators/generateFetchers.test.ts
@@ -81,7 +81,7 @@ describe("generateFetchers", () => {
       import { petstoreFetch } from \\"./petstoreFetcher\\";
       import type * as Schemas from \\"./petstoreSchemas\\";
       import type * as Responses from \\"./petstoreResponses\\";
-      import { ServerErrorStatus } from \\"./petstoreUtils\\";
+      import type { ServerErrorStatus } from \\"./petstoreUtils\\";
 
       export type ListPetsError = Fetcher.ErrorWrapper<{
           status: 404;
@@ -125,7 +125,7 @@ describe("generateFetchers", () => {
       import { fetch } from \\"./fetcher\\";
       import type * as Schemas from \\"./petstoreSchemas\\";
       import type * as Responses from \\"./petstoreResponses\\";
-      import { ServerErrorStatus } from \\"./utils\\";
+      import type { ServerErrorStatus } from \\"./utils\\";
 
       export type ListPetsError = Fetcher.ErrorWrapper<{
           status: 404;
@@ -176,7 +176,7 @@ describe("generateFetchers", () => {
       import { petstoreFetch, PetstoreFetcherExtraProps } from \\"./petstoreFetcher\\";
       import type * as Schemas from \\"./petstoreSchemas\\";
       import type * as Responses from \\"./petstoreResponses\\";
-      import { ServerErrorStatus } from \\"./petstoreUtils\\";
+      import type { ServerErrorStatus } from \\"./petstoreUtils\\";
 
       export type ListPetsError = Fetcher.ErrorWrapper<{
           status: 404;
@@ -228,7 +228,7 @@ describe("generateFetchers", () => {
       import { petstoreFetch } from \\"./petstoreFetcher\\";
       import type * as Schemas from \\"./petstoreSchemas\\";
       import type * as Responses from \\"./petstoreResponses\\";
-      import { ServerErrorStatus } from \\"./petstoreUtils\\";
+      import type { ServerErrorStatus } from \\"./petstoreUtils\\";
 
       export type ListPetsError = Fetcher.ErrorWrapper<{
           status: 404;

--- a/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
@@ -1143,7 +1143,7 @@ describe("generateReactQueryComponents", () => {
       import type * as Fetcher from \\"./petstoreFetcher\\";
       import { petstoreFetch } from \\"./petstoreFetcher\\";
       import type * as Schemas from \\"./petstoreSchemas\\";
-      import { ServerErrorStatus } from \\"./petstoreUtils\\";
+      import type { ServerErrorStatus } from \\"./petstoreUtils\\";
 
       export type ListPetsError = Fetcher.ErrorWrapper<{
           status: ServerErrorStatus;


### PR DESCRIPTION
Hi,

Really nicely thought-out tool!
The project we would like to use it with has `"importsNotUsedAsValues"` set to `error` in `tsconfig.json`. Therefore the generated 
```
import { ClientErrorStatus, ServerErrorStatus } from './<prefix>Utils';
```
causes an error in Typescript.