### PR TITLE
Support FormData in the TS fetcher generator

### DIFF
--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -20,7 +20,7 @@ export const getFetcher = ({
       : `export type ${pascal(prefix)}FetcherExtraProps = {
       /**
        * You can add some extra props to your generated fetchers.
-       * 
+       *
        * Note: You need to re-gen after adding the first property to
        * have the \`${pascal(prefix)}FetcherExtraProps\` injected in \`${pascal(
           prefix
@@ -31,7 +31,7 @@ export const getFetcher = ({
 
 const baseUrl = ${baseUrl ? `"${baseUrl}"` : `""; // TODO add your baseUrl`}
 
-export type ErrorWrapper<TError> = 
+export type ErrorWrapper<TError> =
   | TError
   | { status: "unknown"; payload: string };
 
@@ -73,16 +73,27 @@ export async function ${camel(prefix)}Fetch<
   TPathParams
 >): Promise<TData> {
   try {
+    const requestHeaders: HeadersInit = {
+      "Content-Type": "application/json",
+      ...headers
+    };
+
+    /**
+     * As the fetch API is being used, when multipart/form-data is specified
+     * the Content-Type header must be deleted so that the browser can set
+     * the correct boundary.
+     * https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects#sending_files_using_a_formdata_object
+     */
+    if (requestHeaders["Content-Type"].toLowerCase().includes("multipart/form-data")) {
+      delete requestHeaders["Content-Type"];
+    }
+
     const response = await window.fetch(\`\${baseUrl}\${resolveUrl(url, queryParams, pathParams)}\`,
       {
         signal,
         method: method.toUpperCase(),
         body: body ? (body instanceof FormData ? body : JSON.stringify(body)) : undefined,
-        headers: headers
-          ? headers
-          : {
-              "Content-Type": "application/json"
-            }
+        headers: requestHeaders
       }
     );
     if (!response.ok) {

--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -81,8 +81,7 @@ export async function ${camel(prefix)}Fetch<
         headers: headers
           ? headers
           : {
-              "Content-Type": "application/json",
-              ...headers
+              "Content-Type": "application/json"
             }
       }
     );

--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -78,10 +78,12 @@ export async function ${camel(prefix)}Fetch<
         signal,
         method: method.toUpperCase(),
         body: body ? (body instanceof FormData ? body : JSON.stringify(body)) : undefined,
-        headers: {
-          "Content-Type": "application/json",
-          ...headers,
-        },
+        headers: headers
+          ? headers
+          : {
+              "Content-Type": "application/json",
+              ...headers
+            }
       }
     );
     if (!response.ok) {

--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -54,7 +54,7 @@ export type ${pascal(
 export async function ${camel(prefix)}Fetch<
   TData,
   TError,
-  TBody extends {} | undefined | null,
+  TBody extends {} | FormData | undefined | null,
   THeaders extends {},
   TQueryParams extends {},
   TPathParams extends {}
@@ -77,7 +77,7 @@ export async function ${camel(prefix)}Fetch<
       {
         signal,
         method: method.toUpperCase(),
-        body: body ? JSON.stringify(body) : undefined,
+        body: body ? (body instanceof FormData ? body : JSON.stringify(body)) : undefined,
         headers: {
           "Content-Type": "application/json",
           ...headers,


### PR DESCRIPTION
Support for FormData in the TS fetcher generator.

At the moment, if you pass in FormData as the body, (and manually set headers to  "Content-Type": "multipart/form-data") the body is stringified. This breaks posting FormData as the object should not be stringified.