### PR TITLE
fix: Support for nullable enums

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
@@ -69,6 +69,18 @@ describe("schemaToTypeAliasDeclaration", () => {
     );
   });
 
+  it("should generate nullable enums (strings)", () => {
+    const schema: SchemaObject = {
+      type: "string",
+      enum: ["foo", "bar", "baz"],
+      nullable: true,
+    };
+
+    expect(printSchema(schema)).toBe(
+      `export type Test = "foo" | "bar" | "baz" | null;`
+    );
+  });
+
   it("should generate enums (numbers)", () => {
     const schema: SchemaObject = {
       type: "integer",

--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
@@ -126,8 +126,8 @@ export const getType = (
   }
 
   if (schema.enum) {
-    return f.createUnionTypeNode(
-      schema.enum.map((value) => {
+    return f.createUnionTypeNode([
+      ...schema.enum.map((value) => {
         if (typeof value === "string") {
           return f.createLiteralTypeNode(f.createStringLiteral(value));
         }
@@ -140,8 +140,9 @@ export const getType = (
           );
         }
         return f.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-      })
-    );
+      }),
+      ...(schema.nullable ? [f.createLiteralTypeNode(f.createNull())] : []),
+    ]);
   }
 
   // Handle implicit object


### PR DESCRIPTION
I have fixed the problem of `null` is not included in the union when converting nullable enums.

Input:
```yml
test:
  type: string
  enum: [foo, bar, baz]
  nullable: true
```

Expect:
```ts
export type Test = "foo" | "bar" | "baz" | null;
```

Actual:
```ts
export type Test = "foo" | "bar" | "baz";
```