### PR TITLE
fix: Allow components to have dots in their names

### DIFF
--- a/plugins/typescript/src/core/getParamsGroupByType.ts
+++ b/plugins/typescript/src/core/getParamsGroupByType.ts
@@ -25,7 +25,7 @@ export const getParamsGroupByType = (
       if (isReferenceObject(p)) {
         const schema = get(
           components,
-          p.$ref.replace("#/components/", "").replace("/", ".")
+          p.$ref.replace("#/components/", "").split("/")
         );
         if (!schema) {
           throw new Error(`${p.$ref} not found!`);

--- a/plugins/typescript/src/core/isRequestBodyOptional.test.ts
+++ b/plugins/typescript/src/core/isRequestBodyOptional.test.ts
@@ -110,4 +110,33 @@ describe("isRequestBodyOptional", () => {
       })
     ).toBe(false);
   });
+
+  it("should resolve with dots in names", () => {
+    expect(
+      isRequestBodyOptional({
+        requestBody: {
+          $ref: "#/components/requestBodies/Foo.Request",
+        },
+        components: {
+          requestBodies: {
+            "Foo.Request": {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      foo: {
+                        type: "string",
+                      },
+                    },
+                    required: ["foo"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    ).toBe(false);
+  });
 });

--- a/plugins/typescript/src/core/isRequestBodyOptional.ts
+++ b/plugins/typescript/src/core/isRequestBodyOptional.ts
@@ -41,7 +41,7 @@ export const isRequestBodyOptional = ({
 
     const schema: RequestBodyObject | ReferenceObject = get(
       components,
-      requestBody.$ref.replace("#/components/", "").replace("/", ".")
+      requestBody.$ref.replace("#/components/", "").split("/")
     );
 
     if (!schema) {


### PR DESCRIPTION
Instead of `get(foo, "a.b.c")` use `get(foo, ["a", "b.c"])`