### PR TITLE
fix: Check that property is an object

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
@@ -227,7 +227,7 @@ export const getType = (
       const members: ts.TypeElement[] = Object.entries(
         schema.properties || {}
       ).map(([key, property]) => {
-        const isEnum = "enum" in property && useEnumsConfigBase;
+        const isEnum = typeof property === "object" && "enum" in property && useEnumsConfigBase;
 
         const propertyNode = f.createPropertySignature(
           undefined,


### PR DESCRIPTION
In cases such as `additionalProperties: false`