### PR TITLE
Fix path params match

### DIFF
--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -67,12 +67,19 @@ export const getContext = (prefix: string, componentsFile: string) =>
     return queryKey;
   }
   // Helpers
+  export const parseToCamelCaseIfKebabCase = (key: string) => {
+    if (key.includes('-')) {
+      return key.replace(/-([a-z])/g, (g) => g[1].toUpperCase())
+    }
+    return key
+  }
+
   const resolvePathParam = (
     key: string,
     pathParams: Record<string, string>
   ) => {
     if (key.startsWith("{") && key.endsWith("}")) {
-      return pathParams[key.slice(1, -1)];
+      return pathParams[parseToCamelCaseIfKebabCase(key.slice(1, -1))];
     }
     return key;
   };

--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -130,13 +130,21 @@ export async function ${camel(prefix)}Fetch<
   }
 }
 
-const resolveUrl = (
-  url: string,
-  queryParams: Record<string, string> = {},
-  pathParams: Record<string, string> = {}
-) => {
-  let query = new URLSearchParams(queryParams).toString();
+const resolveUrl = (url: string, queryParams: Record<string, string> = {}, pathParams: Record<string, string> = {}) => {
+  let query = new URLSearchParams(queryParams).toString()
   if (query) query = \`?\${query}\`;
-  return url.replace(/\\{\\w*\\}/g, (key) => pathParams[key.slice(1, -1)]) + query;
-};
+  return (
+    url.replace(/\{[\w-]*\}/g, (key) => {
+      const keyWithoutCurlyBrackets = key.slice(1, -1)
+      return pathParams[parseToCamelCaseIfKebabCase(keyWithoutCurlyBrackets)]
+    }) + query
+  )
+}
+const parseToCamelCaseIfKebabCase = (key: string) => {
+  if (key.includes('-')) {
+    return key.replace(/-([a-z])/g, (g) => g[1].toUpperCase())
+  }
+  return key
+}
+
 `;


### PR DESCRIPTION
### Description:

Related issue: #164 

This pull request addresses an issue with the handling of kebab-case path parameters in the resolveUrl function.

### Changes:

Updated the regex used in the resolveUrl function to match kebab-case path parameters: /{[\w-]*}/g.

Added a parseToCamelCaseIfKebabCase function to convert kebab-case path parameter keys to camelCase when accessing the pathParams object.

Modified the resolveUrl function to use the parseToCamelCaseIfKebabCase function when accessing path parameter keys.

With these changes, the resolveUrl function should now properly handle kebab-case path parameters and generate the correct URLs. 