### PR TITLE
remove "initialData" from omitted options in useQuery

### DIFF
--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -664,7 +664,6 @@ const createUseQueryOptionsType = (
     f.createUnionTypeNode([
       f.createLiteralTypeNode(f.createStringLiteral("queryKey")),
       f.createLiteralTypeNode(f.createStringLiteral("queryFn")),
-      f.createLiteralTypeNode(f.createStringLiteral("initialData")),
     ]),
   ]);
 


### PR DESCRIPTION
# I want to use initialData option when using the generated react-query queries, so I deleted the exclution from the type