### PR TITLE
add camelcase option to schema type generation

### DIFF
--- a/plugins/typescript/src/generators/generateSchemaTypes.ts
+++ b/plugins/typescript/src/generators/generateSchemaTypes.ts
@@ -56,14 +56,15 @@ export const generateSchemaTypes = async (
     componentSchema.reduce<ts.Node[]>(
       (mem, [name, schema]) => [
         ...mem,
-        ...schemaToTypeAliasDeclaration(
+        ...schemaToTypeAliasDeclaration( // @note schemaToTypeAliasDeclaration called here
           name,
           schema,
           {
             openAPIDocument: context.openAPIDocument,
             currentComponent: "schemas",
           },
-          config.useEnums
+          config.useEnums,
+          config.useCamelCasedProps
         ),
       ],
       []
@@ -91,7 +92,7 @@ export const generateSchemaTypes = async (
       const enumSchemas = enumSchemaEntries.reduce<ts.Node[]>(
         (mem, [name, schema]) => [
           ...mem,
-          ...schemaToEnumDeclaration(name, schema, {
+          ...schemaToEnumDeclaration(name, schema, { // @note schemaToEnumDeclaration called here
             openAPIDocument: context.openAPIDocument,
             currentComponent: "schemas",
           }),
@@ -99,7 +100,7 @@ export const generateSchemaTypes = async (
         []
       );
 
-      const componentsSchemas = handleTypeAlias(
+      const componentsSchemas = handleTypeAlias( // @note schemaToTypeAliasDeclaration indirectly called here
         componentSchemaEntries.filter(
           ([name]) => !enumSchemaEntries.some(([enumName]) => name === enumName)
         )
@@ -107,7 +108,7 @@ export const generateSchemaTypes = async (
 
       schemas.push(...enumSchemas, ...componentsSchemas);
     } else {
-      const componentsSchemas = handleTypeAlias(componentSchemaEntries);
+      const componentsSchemas = handleTypeAlias(componentSchemaEntries); // @note schemaToTypeAliasDeclaration called here
       schemas.push(...componentsSchemas);
     }
 
@@ -131,10 +132,12 @@ export const generateSchemaTypes = async (
 
       return [
         ...mem,
-        ...schemaToTypeAliasDeclaration(name, mediaType?.schema || {}, {
+        ...schemaToTypeAliasDeclaration(name, mediaType?.schema || {}, { // @note schemaToTypeAliasDeclaration called here
           openAPIDocument: context.openAPIDocument,
           currentComponent: "responses",
-        }),
+        },
+          undefined,
+          config.useCamelCasedProps),
       ];
     }, []);
 
@@ -161,10 +164,12 @@ export const generateSchemaTypes = async (
 
       return [
         ...mem,
-        ...schemaToTypeAliasDeclaration(name, mediaType.schema, {
+        ...schemaToTypeAliasDeclaration(name, mediaType.schema, { // @note schemaToTypeAliasDeclaration called here
           openAPIDocument: context.openAPIDocument,
           currentComponent: "requestBodies",
-        }),
+        },
+          undefined,
+          config.useCamelCasedProps),
       ];
     }, []);
 
@@ -190,10 +195,12 @@ export const generateSchemaTypes = async (
       }
       return [
         ...mem,
-        ...schemaToTypeAliasDeclaration(name, parameterObject.schema, {
+        ...schemaToTypeAliasDeclaration(name, parameterObject.schema, { // @note schemaToTypeAliasDeclaration called here
           openAPIDocument: context.openAPIDocument,
           currentComponent: "parameters",
-        }),
+        },
+          undefined,
+          config.useCamelCasedProps),
       ];
     }, []);
 

--- a/plugins/typescript/src/generators/types.ts
+++ b/plugins/typescript/src/generators/types.ts
@@ -31,4 +31,10 @@ export type ConfigBase = {
    * @default false
    */
   useEnums?: boolean;
+  /**
+   * Uses camelized property names instead of snake case.
+   *
+   * @default false
+   */
+  useCamelCasedProps?: boolean;
 };


### PR DESCRIPTION
This pr is regarding the implementation of the feature request in this issue: https://github.com/fabien0102/openapi-codegen/issues/213

This pr adds the following features:
- optional config parameter `useCamelCasedProps`
- camelcasing of schema type parameters.

The new config param `useCamelCasedProps` has the following effect on the schema:
```ts
    const schema: SchemaObject = {
      type: "object",
      properties: {
        ["foo_bar"]: {
          type: "string",
        },
      },
    };

// resulting type for `useCamelCasedProps == false` (as usual)
export type Test = {
          foo_bar?: string;
}

// resulting type for `useCamelCasedProps == true` with the new addition
export type Test = {
          fooBar?: string;
}
```

## This pr is still in DRAFT because:
With the current state of this pr the fetchers will fail to get parse the received json correctly, as the received data will be in `snake_case` and the types to cast to would be in `camelCase`. A solution to make this work, would be a configurable adjustment to the fetcher template (`./plugins/typescript/src/core/templates/fetcher.ts`) that applies `camelCase` to incoming request data and that applies `snake_case` to outgoing data. (exact implementation is still to be figured out)

@fabien0102 Please let me know whether you would be interested in having this feature added, and if so i can try to spend the additional time needed to make this work. Any tips/comments/improvements are very welcome!