### PR TITLE
feat: Support nullable on allOf schemas

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
@@ -628,9 +628,9 @@ describe("schemaToTypeAliasDeclaration", () => {
           { type: "object", properties: { bar: { type: "number" } } },
         ],
         properties: {
-          foobar: {type: "string"}
+          foobar: { type: "string" },
         },
-        required: ['foo', 'foobar']
+        required: ["foo", "foobar"],
       };
 
       expect(printSchema(schema)).toMatchInlineSnapshot(`
@@ -641,7 +641,7 @@ describe("schemaToTypeAliasDeclaration", () => {
       };"
     `);
     });
-    
+
     it("should combine additionalProperties and allOf", () => {
       const schema: SchemaObject = {
         allOf: [
@@ -649,8 +649,8 @@ describe("schemaToTypeAliasDeclaration", () => {
           { type: "object", properties: { bar: { type: "number" } } },
         ],
         additionalProperties: {
-          type: "string"
-        }
+          type: "string",
+        },
       };
 
       expect(printSchema(schema)).toMatchInlineSnapshot(`
@@ -662,7 +662,7 @@ describe("schemaToTypeAliasDeclaration", () => {
       };"
     `);
     });
-    
+
     it("should combine properties & additionalProperties & allOf", () => {
       const schema: SchemaObject = {
         allOf: [
@@ -670,12 +670,12 @@ describe("schemaToTypeAliasDeclaration", () => {
           { type: "object", properties: { bar: { type: "number" } } },
         ],
         additionalProperties: {
-          type: "string"
+          type: "string",
         },
         properties: {
-          foobar: {type: "string"}
+          foobar: { type: "string" },
         },
-        required: ['bar', 'foobar']
+        required: ["bar", "foobar"],
       };
 
       expect(printSchema(schema)).toMatchInlineSnapshot(`
@@ -686,6 +686,23 @@ describe("schemaToTypeAliasDeclaration", () => {
       } & {
           [key: string]: string;
       };"
+    `);
+    });
+
+    it("should combine nullable & allOf", () => {
+      const schema: SchemaObject = {
+        allOf: [
+          { type: "object", properties: { foo: { type: "string" } } },
+          { type: "object", properties: { bar: { type: "number" } } },
+        ],
+        nullable: true,
+      };
+
+      expect(printSchema(schema)).toMatchInlineSnapshot(`
+      "export type Test = {
+          foo?: string;
+          bar?: number;
+      } | null;"
     `);
     });
 

--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
@@ -142,10 +142,13 @@ export const getType = (
         additionalProperties: schema.additionalProperties
       });
     }
-    return getAllOf([
-      ...schema.allOf,
-      ...adHocSchemas
-     ], context);
+    return f.createUnionTypeNode([
+      getAllOf([
+        ...schema.allOf,
+        ...adHocSchemas
+      ], context),
+      ...(schema.nullable ? [f.createLiteralTypeNode(f.createNull())] : []),
+    ]);
   }
 
   if (schema.enum) {


### PR DESCRIPTION
I'm currently using @nestjs/swagger and for nested references it generates the following openapi schema (trimmed for readability):

```json
{
  "openapi": "3.0.0",
  "paths": {},
  "components": {
    "schemas": {
      "HydratedAssetDto": {
        "type": "object",
        "properties": {}
      },
      "HydratedPackageDto": {
        "type": "object",
        "properties": {
          "asset": {
            "nullable": true,
            "allOf": [{ "$ref": "#/components/schemas/HydratedAssetDto" }]
          }
        }
      }
    }
  }
}
```

In my case I need to ensure `HydratedPackageDto.asset` will have type `HydratedAssetDto | null`
I was using https://www.npmjs.com/package/openapi-typescript before and it was generating that type for `allOf` with `nullable`
I didn't go through the spec to 100% confirm this is legal, but it looks fine 😅
If you have a suggestion on how to get to the same result with a different schema I'm all ears