### PR TITLE
feat: Added config formatFilename to allow more custom formatting of filenames

### DIFF
--- a/plugins/typescript/src/generators/generateFetchers.ts
+++ b/plugins/typescript/src/generators/generateFetchers.ts
@@ -65,7 +65,12 @@ export const generateFetchers = async (context: Context, config: Config) => {
   const filenamePrefix =
     c.snake(config.filenamePrefix ?? context.openAPIDocument.info.title) + "-";
 
-  const formatFilename = config.filenameCase ? c[config.filenameCase] : c.camel;
+  const formatFilename =
+    typeof config.formatFilename === "function"
+      ? config.formatFilename
+      : config.filenameCase
+        ? c[config.filenameCase]
+        : c.camel;
 
   const filename = formatFilename(filenamePrefix + "-components");
 

--- a/plugins/typescript/src/generators/generateReactQueryComponents.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.ts
@@ -71,7 +71,12 @@ export const generateReactQueryComponents = async (
   const filenamePrefix =
     c.snake(config.filenamePrefix ?? context.openAPIDocument.info.title) + "-";
 
-  const formatFilename = config.filenameCase ? c[config.filenameCase] : c.camel;
+  const formatFilename =
+    typeof config.formatFilename === "function"
+      ? config.formatFilename
+      : config.filenameCase
+        ? c[config.filenameCase]
+        : c.camel;
 
   const filename = formatFilename(filenamePrefix + "-components");
 

--- a/plugins/typescript/src/generators/generateReactQueryFunctions.ts
+++ b/plugins/typescript/src/generators/generateReactQueryFunctions.ts
@@ -72,7 +72,12 @@ export const generateReactQueryFunctions = async (
   const filenamePrefix =
     c.snake(config.filenamePrefix ?? context.openAPIDocument.info.title) + "-";
 
-  const formatFilename = config.filenameCase ? c[config.filenameCase] : c.camel;
+  const formatFilename =
+    typeof config.formatFilename === "function"
+      ? config.formatFilename
+      : config.filenameCase
+        ? c[config.filenameCase]
+        : c.camel;
 
   const filename = formatFilename(filenamePrefix + "-functions");
 

--- a/plugins/typescript/src/generators/generateSchemaTypes.ts
+++ b/plugins/typescript/src/generators/generateSchemaTypes.ts
@@ -72,7 +72,12 @@ export const generateSchemaTypes = async (
   const filenamePrefix =
     c.snake(config.filenamePrefix ?? context.openAPIDocument.info.title) + "-";
 
-  const formatFilename = config.filenameCase ? c[config.filenameCase] : c.camel;
+  const formatFilename =
+    typeof config.formatFilename === "function"
+      ? config.formatFilename
+      : config.filenameCase
+        ? c[config.filenameCase]
+        : c.camel;
   const files = {
     requestBodies: formatFilename(filenamePrefix + "-request-bodies"),
     schemas: formatFilename(filenamePrefix + "-schemas"),

--- a/plugins/typescript/src/generators/types.ts
+++ b/plugins/typescript/src/generators/types.ts
@@ -26,6 +26,11 @@ export type ConfigBase = {
    */
   filenameCase?: keyof Pick<typeof c, "snake" | "camel" | "kebab" | "pascal">;
   /**
+   * Allows customizing the filename.
+   * If provided, `filenameCase` will be ignored.
+   */
+  formatFilename?: (filename: string) => string;
+  /**
    * Allows using explicit enums instead of string unions.
    *
    * @default false


### PR DESCRIPTION
I have a special need where I want to add `.gen` at the end of the files that are always regenerated by the codegen.
Instead of baking that logic into this lib, I thought that allowing to provide a custom formatter would be generic enough and I can do a mapping on my side like this

```ts
const formatFilename = (filename: string) => {
      filename = _.kebabCase(filename);
      const needsDotGen = [
        `${filenamePrefix}-components`,
        `${filenamePrefix}-request-bodies`,
        `${filenamePrefix}-schemas`,
        `${filenamePrefix}-parametersF`,
        `${filenamePrefix}-responses`,
      ].includes(filename);
      return `${filename}${needsDotGen ? ".gen" : ""}`;
    };

    const { schemasFiles } = await generateSchemaTypes(context, {
      filenamePrefix,
      formatFilename,
    });
    await generateReactQueryComponents(context, {
      schemasFiles,
      filenamePrefix,
      formatFilename,
    });
```