### PR TITLE
fix: Generate operationId the same between ReactQueryComponents and ReactQueryFunctions

### DIFF
--- a/plugins/typescript/src/core/createOperationQueryFnNodes.ts
+++ b/plugins/typescript/src/core/createOperationQueryFnNodes.ts
@@ -19,6 +19,7 @@ export const createOperationQueryFnNodes = ({
   variablesType,
   fetcherFn,
   operation,
+  operationId,
   url,
   verb,
   name,
@@ -32,6 +33,7 @@ export const createOperationQueryFnNodes = ({
   queryParamsType: ts.TypeNode;
   variablesType: ts.TypeNode;
   operation: OperationObject;
+  operationId: string;
   fetcherFn: string;
   url: string;
   verb: string;
@@ -161,9 +163,7 @@ export const createOperationQueryFnNodes = ({
                           ),
                           f.createPropertyAssignment(
                             f.createIdentifier("operationId"),
-                            f.createStringLiteral(
-                              operation.operationId as string
-                            )
+                            f.createStringLiteral(operationId)
                           ),
                           f.createShorthandPropertyAssignment(
                             f.createIdentifier("variables"),

--- a/plugins/typescript/src/generators/generateReactQueryFunctions.ts
+++ b/plugins/typescript/src/generators/generateReactQueryFunctions.ts
@@ -210,6 +210,7 @@ export const generateReactQueryFunctions = async (
               queryParamsType,
               headersType,
               operation,
+              operationId,
               fetcherFn,
               url: route,
               verb,


### PR DESCRIPTION
Since I generated the context from ReactQueryComponents, if I tried to then generate ReactQueryFunctions I would get typings errors on the operationId because the 2 wouldn't generate the same casing for operationId.

At first I thought I could use a mix of both for different purposes.
I might just squeeze what I want in components instead (Maybe PR coming, still need to think about it a bit).
Still figured this would be a good improvement