### PR TITLE
feat: New usePrepare<Op> hook to enable reactQuery.useQueries

### DIFF
--- a/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
+++ b/plugins/typescript/src/generators/generateReactQueryComponents.test.ts
@@ -109,12 +109,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>({
+      export const usePrepareListPets = <TData = ListPetsResponse>(options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ListPetsVariables): reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }),
           queryFn: ({ signal }) => fetchListPets({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Get all the pets
+       */
+      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareListPets(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets\\";
@@ -233,12 +238,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>({
+      export const usePrepareListPets = <TData = ListPetsResponse>(options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ListPetsVariables): reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }),
           queryFn: ({ signal }) => fetchListPets({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Get all the pets
+       */
+      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareListPets(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets\\";
@@ -339,12 +349,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Info for a specific pet
        */
-      export const useShowPetById = <TData = ShowPetByIdResponse>(variables: ShowPetByIdVariables, options?: Omit<reactQuery.UseQueryOptions<ShowPetByIdResponse, ShowPetByIdError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ShowPetByIdResponse, ShowPetByIdError, TData>({
+      export const usePrepareShowPetById = <TData = ShowPetByIdResponse>(options?: Omit<reactQuery.UseQueryOptions<ShowPetByIdResponse, ShowPetByIdError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ShowPetByIdVariables): reactQuery.UseQueryOptions<ShowPetByIdResponse, ShowPetByIdError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets/{petId}\\", operationId: \\"showPetById\\", variables }),
           queryFn: ({ signal }) => fetchShowPetById({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Info for a specific pet
+       */
+      export const useShowPetById = <TData = ShowPetByIdResponse>(variables: ShowPetByIdVariables, options?: Omit<reactQuery.UseQueryOptions<ShowPetByIdResponse, ShowPetByIdError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareShowPetById(options); return reactQuery.useQuery<ShowPetByIdResponse, ShowPetByIdError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets/{petId}\\";
@@ -467,12 +482,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>({
+      export const usePrepareListPets = <TData = ListPetsResponse>(options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ListPetsVariables): reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }),
           queryFn: ({ signal }) => fetchListPets({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Get all the pets
+       */
+      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareListPets(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets\\";
@@ -566,12 +586,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>({
+      export const usePrepareListPets = <TData = ListPetsResponse>(options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ListPetsVariables): reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }),
           queryFn: ({ signal }) => fetchListPets({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Get all the pets
+       */
+      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareListPets(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets\\";
@@ -1515,12 +1540,17 @@ describe("generateReactQueryComponents", () => {
       /**
        * Get all the pets
        */
-      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>({
+      export const usePrepareListPets = <TData = ListPetsResponse>(options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const { fetcherOptions, queryOptions, queryKeyFn } = usePetstoreContext(options); return (variables: ListPetsVariables): reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData> => ({
           queryKey: queryKeyFn({ path: \\"/pets\\", operationId: \\"listPets\\", variables }),
           queryFn: ({ signal }) => fetchListPets({ ...fetcherOptions, ...variables }, signal),
           ...options,
           ...queryOptions
       }); };
+
+      /**
+       * Get all the pets
+       */
+      export const useListPets = <TData = ListPetsResponse>(variables: ListPetsVariables, options?: Omit<reactQuery.UseQueryOptions<ListPetsResponse, ListPetsError, TData>, \\"queryKey\\" | \\"queryFn\\" | \\"initialData\\">) => { const prepare = usePrepareListPets(options); return reactQuery.useQuery<ListPetsResponse, ListPetsError, TData>(prepare(variables)); };
 
       export type QueryOperation = {
           path: \\"/pets\\";


### PR DESCRIPTION
The feature I'm looking for is to have a type-safe reliable way to use `useQueries`.
I thought about using ReactQueryFunctions instead of ReactQueryComponents. However, having a mix of both (see #232) is not ideal and causes to have a whole lot of duplicated code.
Since I prefer the hook approach, I wanted a way to make this work.
In the current state it is impossible to extract all the goodies provided by the `use<Op>` hook, namely the `useContext`, the `queryKey` and `queryFn`.

My proposed solution is to make a new hook call `usePrepare<Op>` that returns a function (factory) to then create the queryKey/queryFn from variables.
I'm open to suggestions on naming, not totally sold on it

This is the end result I'm looking for in my app

```ts
  const query = useComponentControllerFindOne({ pathParams: id });
  const findOnePackage = usePreparePackageControllerFindOne({});
  const queries = useQueries({
    queries: query.data?.listIds.map((id) => findOnePackage({ pathParams: { id } })) || [],
  });
  const packages = queries.map(q => q.data)
```