### PR TITLE
feat: Provide types and hook to set the data of a specific operation safely

### DIFF
--- a/plugins/typescript/src/generators/generateReactQueryFunctions.ts
+++ b/plugins/typescript/src/generators/generateReactQueryFunctions.ts
@@ -80,6 +80,7 @@ export const generateReactQueryFunctions = async (
   const contextTypeName = `${c.pascal(filenamePrefix)}Context`;
   const nodes: ts.Node[] = [];
   const keyManagerItems: ts.TypeLiteralNode[] = [];
+  const queryOperationDataTypeItems: ts.TypeElement[] = [];
 
   const fetcherFilename = formatFilename(filenamePrefix + "-fetcher");
   const contextFilename = formatFilename(filenamePrefix + "-context");
@@ -143,8 +144,6 @@ export const generateReactQueryFunctions = async (
           ),
         });
 
-        
-
         const operationFetcherFnName = `fetch${c.pascal(operationId)}`;
         const operationQueryFnName = `${c.pascal(operationId)}Query`;
         const component: "useQuery" | "useMutate" =
@@ -157,7 +156,6 @@ export const generateReactQueryFunctions = async (
         }
 
         if (component === "useQuery") {
-          
           nodes.push(...declarationNodes);
 
           keyManagerItems.push(
@@ -183,6 +181,15 @@ export const generateReactQueryFunctions = async (
                 variablesType
               ),
             ])
+          );
+
+          queryOperationDataTypeItems.push(
+            f.createPropertySignature(
+              undefined,
+              f.createIdentifier(operationId),
+              undefined,
+              dataType
+            )
           );
 
           nodes.push(
@@ -252,6 +259,13 @@ export const generateReactQueryFunctions = async (
         ])
   );
 
+  const queryOperationDataTypes = f.createTypeAliasDeclaration(
+    [f.createModifier(ts.SyntaxKind.ExportKeyword)],
+    "QueryDataTypes",
+    undefined,
+    f.createTypeLiteralNode(queryOperationDataTypeItems)
+  );
+
   const { nodes: usedImportsNodes, keys: usedImportsKeys } = getUsedImports(
     nodes,
     {
@@ -278,6 +292,7 @@ export const generateReactQueryFunctions = async (
       ...usedImportsNodes,
       ...nodes,
       queryKeyManager,
+      queryOperationDataTypes,
     ])
   );
 };

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -100,4 +100,23 @@ export const getContext = (prefix: string, componentsFile: string) =>
   } => {
     return Boolean((operation.variables as any).queryParams);
   };
+
+  /**
+   * Set the data of a query operation
+   * 
+   * @example
+   * const setQueryOperationData = useSetQueryOperationData();
+   * setQueryOperationData({
+   *   operationId: "getUser",
+   *   path: "/users/{id}",
+   *   variables: { pathParams: { id: "1" } }
+   * }, data /* data must have the type expected by that operation * /);
+   */
+  export function useSetQueryOperationData() {
+    const { queryKeyFn } = useAcApiContext();
+    const queryClient = useQueryClient();
+    return <Op extends QueryOperation>(operation: Op, data: QueryDataTypes[Op["operationId"]]) => {
+      queryClient.setQueryData(queryKeyFn(operation), data);
+    };
+  } 
   `;


### PR DESCRIPTION
Example of what this generates for my project

```ts
export type QueryDataTypes = {
  galApiControllerGetHello: undefined;
  configControllerGetOpenApi: undefined;
  workspaceControllerFindAll: WorkspaceControllerFindAllResponse;
  workspaceControllerFindOne: Schemas.WorkspaceDto;
  assetControllerFindAll: AssetControllerFindAllResponse;
  assetControllerFindOne: Schemas.HydratedAssetDto;
  eventControllerFindAllByTargetId: undefined;
  partControllerFindAll: PartControllerFindAllResponse;
  partControllerCountAll: undefined;
  partControllerFindOne: Schemas.HydratedPartDto;
 ...
 };
 ```

Then in my client code I can do the following

```ts
  const queryOperationDataSetter = useSetQueryOperationData();
  const mutation = usePartControllerUpdate();

  const handleSubmit = (body) => {
    mutation.mutate(
      {
        pathParams: { id },
        body,
      },
      {
        onSuccess: (data) => {
          queryOperationDataSetter(
            {
              operationId: "partControllerFindOne",
              path: "/api/v0/parts/{id}",
              variables: { pathParams: { id } },
            },
            data  // data must be compatible with the data type of partControllerFindOne 
          );
        },
      }
    );
  }