### PR TITLE
fix: Update prettier version to 3.2.5

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v1
         if: ${{ steps.release.outputs.releases_created }}
         with:
-          node-version: 16
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages
         if: ${{ steps.release.outputs.releases_created }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "cli": "2.0.0",
-  "plugins/typescript": "8.0.0"
+  "cli": "3.0.0",
+  "plugins/typescript": "9.0.0"
 }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [3.0.0](https://github.com/Karnak19/openapi-codegen/compare/openapi-codegen-cli-v2.0.0...openapi-codegen-cli-v3.0.0) (2024-03-18)
+
+
+### ⚠ BREAKING CHANGES
+
+* Implement query cancellation in react-query generated components ([#95](https://github.com/Karnak19/openapi-codegen/issues/95))
+
+### Features
+
+* [generateFetchers] Add extra props support ([#25](https://github.com/Karnak19/openapi-codegen/issues/25)) ([35fc219](https://github.com/Karnak19/openapi-codegen/commit/35fc219d9c644becdf38b0b3e38e1512d095d2d0))
+* Add `init` command ([#44](https://github.com/Karnak19/openapi-codegen/issues/44)) ([2ccd5ec](https://github.com/Karnak19/openapi-codegen/commit/2ccd5ec45c4bc27908c45a16002afef04f92ed96))
+* Add support for flags in `gen` command ([#27](https://github.com/Karnak19/openapi-codegen/issues/27)) ([ec263c2](https://github.com/Karnak19/openapi-codegen/commit/ec263c2f55e4cc4fcb1bc427bf2c9fd1152f640d))
+* bump typescript & lerna versions ([#89](https://github.com/Karnak19/openapi-codegen/issues/89)) ([cf22aa1](https://github.com/Karnak19/openapi-codegen/commit/cf22aa1b999b86934ec907aa37dc53477ed0a3e2))
+* generate fetchers only ([#22](https://github.com/Karnak19/openapi-codegen/issues/22)) ([b1d5c4a](https://github.com/Karnak19/openapi-codegen/commit/b1d5c4a6cc104904f4bc72777974973cdda7832d))
+* github as openapi source ([#54](https://github.com/Karnak19/openapi-codegen/issues/54)) ([0d054f4](https://github.com/Karnak19/openapi-codegen/commit/0d054f488dfa660f647007002fd80b6ae242b784))
+* Implement query cancellation in react-query generated components ([#95](https://github.com/Karnak19/openapi-codegen/issues/95)) ([450b069](https://github.com/Karnak19/openapi-codegen/commit/450b0696073746615d61ab66a7f09de337139a00))
+
+
+### Bug Fixes
+
+* add typescript as dependency ([22bfb09](https://github.com/Karnak19/openapi-codegen/commit/22bfb091e1617318a38e206d5f88fe3594e0f571))
+* adjust documentation with the current state of the project ([2a55e01](https://github.com/Karnak19/openapi-codegen/commit/2a55e0119e1155c0280cd16e5cee95b39e9e7bca))
+* Bundle cli with react ([#65](https://github.com/Karnak19/openapi-codegen/issues/65)) ([36b9a35](https://github.com/Karnak19/openapi-codegen/commit/36b9a35652b8adb95e70e8bffca0683ff11281d9))
+* Fix `gen --pr` command ([#71](https://github.com/Karnak19/openapi-codegen/issues/71)) ([bc9bed4](https://github.com/Karnak19/openapi-codegen/commit/bc9bed4dfad6820556709736db43357d657dbda2))
+* Fix `path` usage for node 14 ([#34](https://github.com/Karnak19/openapi-codegen/issues/34)) ([4422e61](https://github.com/Karnak19/openapi-codegen/commit/4422e61b317ffd4d3aa0b30340592063c4a222cc))
+* update prettier ([#205](https://github.com/Karnak19/openapi-codegen/issues/205)) ([c8152b9](https://github.com/Karnak19/openapi-codegen/commit/c8152b9b303902997f399690f0a4ac753af497aa))
+* Update prettier version to 3.2.5 ([61381b6](https://github.com/Karnak19/openapi-codegen/commit/61381b64dfce6f94a10661861ea7e09424abce04))
+
 ## [2.0.0](https://github.com/fabien0102/openapi-codegen/compare/cli-v1.6.0...cli-v2.0.0) (2022-09-21)
 
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karnak19/openapi-codegen-cli",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "OpenAPI Codegen cli",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Fabien Bernard",
+  "author": "Basile Vernouillet",
   "keywords": [
     "openapi",
     "codegen",

--- a/cli/package.json
+++ b/cli/package.json
@@ -46,7 +46,7 @@
     "ink": "^3.2.0",
     "js-yaml": "^4.1.0",
     "openapi3-ts": "^2.0.1",
-    "prettier": "^3.0.3",
+    "prettier": "^3.2.5",
     "rxjs": "^7.5.4",
     "slash": "^4.0.0",
     "swagger2openapi": "^7.0.8",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openapi-codegen/cli",
+  "name": "@karnak19/openapi-codegen-cli",
   "version": "2.0.0",
   "description": "OpenAPI Codegen cli",
   "main": "lib/index.js",
@@ -9,7 +9,7 @@
     "openapi-codegen": "lib/cli.js"
   },
   "repository": {
-    "url": "https://github.com/fabien0102/openapi-codegen",
+    "url": "https://github.com/karnak19/openapi-codegen",
     "directory": "cli"
   },
   "publishConfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "husky": "^7.0.2",
         "jest": "^27.2.5",
         "lerna": "^5.5.0",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "pretty-quick": "^3.1.1",
         "typescript": "4.8.2"
       },
@@ -50,7 +50,7 @@
         "ink": "^3.2.0",
         "js-yaml": "^4.1.0",
         "openapi3-ts": "^2.0.1",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "rxjs": "^7.5.4",
         "slash": "^4.0.0",
         "swagger2openapi": "^7.0.8",
@@ -14121,9 +14121,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20687,7 +20687,7 @@
         "js-yaml": "^4.1.0",
         "nock": "^13.2.1",
         "openapi3-ts": "^2.0.1",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "react": "^17.0.2",
         "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-internal": "^1.0.4",
@@ -28168,9 +28168,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "cli": {
       "name": "@karnak19/openapi-codegen-cli",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.5.10",
@@ -17181,7 +17181,7 @@
     },
     "plugins/typescript": {
       "name": "@karnak19/openapi-codegen-typescript",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "case": "^1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       }
     },
     "cli": {
-      "name": "@openapi-codegen/cli",
+      "name": "@karnak19/openapi-codegen-cli",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
@@ -2494,6 +2494,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@karnak19/openapi-codegen-cli": {
+      "resolved": "cli",
+      "link": true
+    },
+    "node_modules/@karnak19/openapi-codegen-typescript": {
+      "resolved": "plugins/typescript",
+      "link": true
+    },
     "node_modules/@lerna/add": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-5.5.1.tgz",
@@ -4442,14 +4450,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^13.9.1"
       }
-    },
-    "node_modules/@openapi-codegen/cli": {
-      "resolved": "cli",
-      "link": true
-    },
-    "node_modules/@openapi-codegen/typescript": {
-      "resolved": "plugins/typescript",
-      "link": true
     },
     "node_modules/@parcel/watcher": {
       "version": "2.0.4",
@@ -17180,7 +17180,7 @@
       }
     },
     "plugins/typescript": {
-      "name": "@openapi-codegen/typescript",
+      "name": "@karnak19/openapi-codegen-typescript",
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
@@ -19060,6 +19060,95 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@karnak19/openapi-codegen-cli": {
+      "version": "file:cli",
+      "requires": {
+        "@apollo/client": "^3.5.10",
+        "@graphql-codegen/cli": "^2.6.2",
+        "@graphql-codegen/typescript": "^2.4.5",
+        "@graphql-codegen/typescript-operations": "^2.3.2",
+        "@graphql-codegen/typescript-react-apollo": "^3.2.8",
+        "@rollup/plugin-commonjs": "^22.0.0",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.2",
+        "@swc-node/register": "^1.4.0",
+        "@swc/core": "^1.2.118",
+        "@types/fs-extra": "^9.0.13",
+        "@types/js-yaml": "^4.0.3",
+        "@types/nock": "^11.1.0",
+        "@types/prettier": "^3.0.0",
+        "@types/react": "^17.0.39",
+        "@types/slash": "^3.0.0",
+        "case": "^1.6.3",
+        "chalk": "^5.0.0",
+        "cli-highlight": "^2.1.11",
+        "clipanion": "^3.2.0-rc.10",
+        "fs-extra": "^10.0.0",
+        "got": "^12.0.0",
+        "got-fetch": "^5.1.1",
+        "graphql": "^15.8.0",
+        "ink": "^3.2.0",
+        "js-yaml": "^4.1.0",
+        "nock": "^13.2.1",
+        "openapi3-ts": "^2.0.1",
+        "prettier": "^3.2.5",
+        "react": "^17.0.2",
+        "rollup-plugin-auto-external": "^2.0.0",
+        "rollup-plugin-internal": "^1.0.4",
+        "rollup-plugin-preserve-shebang": "^1.0.1",
+        "rxjs": "^7.5.4",
+        "slash": "^4.0.0",
+        "swagger2openapi": "^7.0.8",
+        "tslib": "^2.3.1",
+        "typanion": "^3.7.1",
+        "typescript": "4.8.2"
+      },
+      "dependencies": {
+        "@types/prettier": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
+          "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
+          "dev": true,
+          "requires": {
+            "prettier": "*"
+          }
+        },
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+        },
+        "rxjs": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+        }
+      }
+    },
+    "@karnak19/openapi-codegen-typescript": {
+      "version": "file:plugins/typescript",
+      "requires": {
+        "@types/lodash": "^4.14.175",
+        "@types/pluralize": "^0.0.29",
+        "@types/qs": "^6.9.7",
+        "case": "^1.6.3",
+        "lodash": "^4.17.21",
+        "openapi3-ts": "^2.0.1",
+        "pluralize": "^8.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0",
+        "typescript": "4.8.2"
+      }
+    },
     "@lerna/add": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-5.5.1.tgz",
@@ -20653,95 +20742,6 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^13.9.1"
-      }
-    },
-    "@openapi-codegen/cli": {
-      "version": "file:cli",
-      "requires": {
-        "@apollo/client": "^3.5.10",
-        "@graphql-codegen/cli": "^2.6.2",
-        "@graphql-codegen/typescript": "^2.4.5",
-        "@graphql-codegen/typescript-operations": "^2.3.2",
-        "@graphql-codegen/typescript-react-apollo": "^3.2.8",
-        "@rollup/plugin-commonjs": "^22.0.0",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.3.0",
-        "@rollup/plugin-typescript": "^8.3.2",
-        "@swc-node/register": "^1.4.0",
-        "@swc/core": "^1.2.118",
-        "@types/fs-extra": "^9.0.13",
-        "@types/js-yaml": "^4.0.3",
-        "@types/nock": "^11.1.0",
-        "@types/prettier": "^3.0.0",
-        "@types/react": "^17.0.39",
-        "@types/slash": "^3.0.0",
-        "case": "^1.6.3",
-        "chalk": "^5.0.0",
-        "cli-highlight": "^2.1.11",
-        "clipanion": "^3.2.0-rc.10",
-        "fs-extra": "^10.0.0",
-        "got": "^12.0.0",
-        "got-fetch": "^5.1.1",
-        "graphql": "^15.8.0",
-        "ink": "^3.2.0",
-        "js-yaml": "^4.1.0",
-        "nock": "^13.2.1",
-        "openapi3-ts": "^2.0.1",
-        "prettier": "^3.2.5",
-        "react": "^17.0.2",
-        "rollup-plugin-auto-external": "^2.0.0",
-        "rollup-plugin-internal": "^1.0.4",
-        "rollup-plugin-preserve-shebang": "^1.0.1",
-        "rxjs": "^7.5.4",
-        "slash": "^4.0.0",
-        "swagger2openapi": "^7.0.8",
-        "tslib": "^2.3.1",
-        "typanion": "^3.7.1",
-        "typescript": "4.8.2"
-      },
-      "dependencies": {
-        "@types/prettier": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-          "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-          "dev": true,
-          "requires": {
-            "prettier": "*"
-          }
-        },
-        "chalk": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-        },
-        "rxjs": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
-        }
-      }
-    },
-    "@openapi-codegen/typescript": {
-      "version": "file:plugins/typescript",
-      "requires": {
-        "@types/lodash": "^4.14.175",
-        "@types/pluralize": "^0.0.29",
-        "@types/qs": "^6.9.7",
-        "case": "^1.6.3",
-        "lodash": "^4.17.21",
-        "openapi3-ts": "^2.0.1",
-        "pluralize": "^8.0.0",
-        "tslib": "^2.3.1",
-        "tsutils": "^3.21.0",
-        "typescript": "4.8.2"
       }
     },
     "@parcel/watcher": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "OpenAPI code generator framework",
   "repository": "https://github.com/karnak19/openapi-codegen",
-  "author": "Fabien Bernard",
+  "author": "Basile Vernouillet",
   "license": "MIT",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-codegen",
   "version": "0.0.1",
   "description": "OpenAPI code generator framework",
-  "repository": "https://github.com/fabien0102/openapi-codegen",
+  "repository": "https://github.com/karnak19/openapi-codegen",
   "author": "Fabien Bernard",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "husky": "^7.0.2",
     "jest": "^27.2.5",
     "lerna": "^5.5.0",
-    "prettier": "^3.0.3",
+    "prettier": "^3.2.5",
     "pretty-quick": "^3.1.1",
     "typescript": "4.8.2"
   },

--- a/plugins/typescript/CHANGELOG.md
+++ b/plugins/typescript/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [9.0.0](https://github.com/Karnak19/openapi-codegen/compare/openapi-codegen-typescript-v8.0.0...openapi-codegen-typescript-v9.0.0) (2024-03-18)
+
+
+### ⚠ BREAKING CHANGES
+
+* Add camelize to queryKeyFn path parameters ([#203](https://github.com/Karnak19/openapi-codegen/issues/203))
+* Support react-query v5 (use object signatures) #179
+* Implement query cancellation in react-query generated components ([#95](https://github.com/Karnak19/openapi-codegen/issues/95))
+* Update to react-query v4 ([#77](https://github.com/Karnak19/openapi-codegen/issues/77))
+* Improve error type safety ([#63](https://github.com/Karnak19/openapi-codegen/issues/63))
+* React query key cache manager ([#49](https://github.com/Karnak19/openapi-codegen/issues/49))
+* Inject query options in context ([#31](https://github.com/Karnak19/openapi-codegen/issues/31))
+
+### Features
+
+* [generateFetchers] Add extra props support ([#25](https://github.com/Karnak19/openapi-codegen/issues/25)) ([35fc219](https://github.com/Karnak19/openapi-codegen/commit/35fc219d9c644becdf38b0b3e38e1512d095d2d0))
+* Add `init` command ([#44](https://github.com/Karnak19/openapi-codegen/issues/44)) ([2ccd5ec](https://github.com/Karnak19/openapi-codegen/commit/2ccd5ec45c4bc27908c45a16002afef04f92ed96))
+* Add fetchers dictionary by tag ([#45](https://github.com/Karnak19/openapi-codegen/issues/45)) ([b2751d0](https://github.com/Karnak19/openapi-codegen/commit/b2751d03c23ccb841822eafb03d9e579d159dc41))
+* add react-query generator ([2ecbcf8](https://github.com/Karnak19/openapi-codegen/commit/2ecbcf8cb803163a57303ad9f8d39fcf36dc108c))
+* Add support for flags in `gen` command ([#27](https://github.com/Karnak19/openapi-codegen/issues/27)) ([ec263c2](https://github.com/Karnak19/openapi-codegen/commit/ec263c2f55e4cc4fcb1bc427bf2c9fd1152f640d))
+* added file upload and download support ([#84](https://github.com/Karnak19/openapi-codegen/issues/84)) ([3a15e0c](https://github.com/Karnak19/openapi-codegen/commit/3a15e0ceb55b8d93947d06b99b699f405af3d469))
+* Allow generating code without a prefix ([#50](https://github.com/Karnak19/openapi-codegen/issues/50)) ([cb4d68f](https://github.com/Karnak19/openapi-codegen/commit/cb4d68fcd52ce0a14ae1f378071fbc2a4e7d1877))
+* bump typescript & lerna versions ([#89](https://github.com/Karnak19/openapi-codegen/issues/89)) ([cf22aa1](https://github.com/Karnak19/openapi-codegen/commit/cf22aa1b999b86934ec907aa37dc53477ed0a3e2))
+* Create Query Functions (eg. for react-router v6.4+) ([#122](https://github.com/Karnak19/openapi-codegen/issues/122)) ([5ff77ef](https://github.com/Karnak19/openapi-codegen/commit/5ff77ef55537036e0ce46b3cc89f391c9892c9f7))
+* enum support ([#153](https://github.com/Karnak19/openapi-codegen/issues/153)) ([aecaa73](https://github.com/Karnak19/openapi-codegen/commit/aecaa738280837256d669b21a1a3de1988b9607d))
+* generate fetchers only ([#22](https://github.com/Karnak19/openapi-codegen/issues/22)) ([b1d5c4a](https://github.com/Karnak19/openapi-codegen/commit/b1d5c4a6cc104904f4bc72777974973cdda7832d))
+* Implement query cancellation in react-query generated components ([#95](https://github.com/Karnak19/openapi-codegen/issues/95)) ([450b069](https://github.com/Karnak19/openapi-codegen/commit/450b0696073746615d61ab66a7f09de337139a00))
+* Improve error type safety ([#63](https://github.com/Karnak19/openapi-codegen/issues/63)) ([d32d84a](https://github.com/Karnak19/openapi-codegen/commit/d32d84a566c52a2b0b7a97b6b240fdf4ca3facca))
+* Inject query options in context ([#31](https://github.com/Karnak19/openapi-codegen/issues/31)) ([0a7fd6d](https://github.com/Karnak19/openapi-codegen/commit/0a7fd6d6b46132ae12df787edd4169bbec76dd81))
+* React query key cache manager ([#49](https://github.com/Karnak19/openapi-codegen/issues/49)) ([4e30ddb](https://github.com/Karnak19/openapi-codegen/commit/4e30ddbbb0db14e5b9c1c54b441218481d8537f6))
+* select support added for react-query components ([#83](https://github.com/Karnak19/openapi-codegen/issues/83)) ([01574bc](https://github.com/Karnak19/openapi-codegen/commit/01574bcb41694d11b928f7d1f3723777001b6b4a))
+* Support FormData in the TS fetcher generator ([#117](https://github.com/Karnak19/openapi-codegen/issues/117)) ([c51203d](https://github.com/Karnak19/openapi-codegen/commit/c51203d77d9fc1cd0414a63538f91c014f2e4841))
+* Support react-query v5 (use object signatures) [#179](https://github.com/Karnak19/openapi-codegen/issues/179) ([e1076af](https://github.com/Karnak19/openapi-codegen/commit/e1076af6387c5eba15306e647bda051c80185164))
+* **typescript:** Improve generated fetcher names ([2aa1b4b](https://github.com/Karnak19/openapi-codegen/commit/2aa1b4b52628450172d39a68838f825c1bcd2a6d))
+* Update to react-query v4 ([#77](https://github.com/Karnak19/openapi-codegen/issues/77)) ([a019e39](https://github.com/Karnak19/openapi-codegen/commit/a019e3936169e39109c5bd2cb5f3eb44d3d771f3))
+
+
+### Bug Fixes
+
+* [#157](https://github.com/Karnak19/openapi-codegen/issues/157) allOf w/ properties ([#158](https://github.com/Karnak19/openapi-codegen/issues/158)) ([9a39e52](https://github.com/Karnak19/openapi-codegen/commit/9a39e5244563b3f57b5be0c55c6e8fc514a5d6ad))
+* Add camelize to queryKeyFn path parameters ([#203](https://github.com/Karnak19/openapi-codegen/issues/203)) ([a24d31b](https://github.com/Karnak19/openapi-codegen/commit/a24d31b721f629f5b5da2c284be61341a5ba616f))
+* Allow components to have dots in their names ([#151](https://github.com/Karnak19/openapi-codegen/issues/151)) ([c91200e](https://github.com/Karnak19/openapi-codegen/commit/c91200e7c714084bcb236e6f0862b74e03b3ba0f))
+* Check that property is an object ([#162](https://github.com/Karnak19/openapi-codegen/issues/162)) ([76005e0](https://github.com/Karnak19/openapi-codegen/commit/76005e0c68e87efe5899e205ae63b7e55fb62eae))
+* error return for fetcher ([#125](https://github.com/Karnak19/openapi-codegen/issues/125)) ([934ea0c](https://github.com/Karnak19/openapi-codegen/commit/934ea0cfcd7dbe78cec965a0b8437ec844b4429a))
+* Fix `gen --pr` command ([#71](https://github.com/Karnak19/openapi-codegen/issues/71)) ([bc9bed4](https://github.com/Karnak19/openapi-codegen/commit/bc9bed4dfad6820556709736db43357d657dbda2))
+* fix baseUrl in fetcherTemplate ([78b2a40](https://github.com/Karnak19/openapi-codegen/commit/78b2a4003bd9b960cdaf58db36ad205a503888a9))
+* fix camelizedPathParams ([#172](https://github.com/Karnak19/openapi-codegen/issues/172)) ([53c7fd0](https://github.com/Karnak19/openapi-codegen/commit/53c7fd02ff28f913a16bb6ab583e36a1b399242c))
+* Fix comment generation ([#58](https://github.com/Karnak19/openapi-codegen/issues/58)) ([f291a32](https://github.com/Karnak19/openapi-codegen/commit/f291a32bb6225d224e6f14089aef8313f50481a6))
+* Fix path param regex ([#166](https://github.com/Karnak19/openapi-codegen/issues/166)) ([59bae62](https://github.com/Karnak19/openapi-codegen/commit/59bae62ce64f9652e4ab15021ed8e61624b69ccc))
+* getReferenceSchema for names with '.' chars ([#141](https://github.com/Karnak19/openapi-codegen/issues/141)) ([865fcf6](https://github.com/Karnak19/openapi-codegen/commit/865fcf654c84ff798cdd063336ab6bf11c843fff))
+* Handle TypeScript breaking changes [#136](https://github.com/Karnak19/openapi-codegen/issues/136) ([#142](https://github.com/Karnak19/openapi-codegen/issues/142)) ([f05ab09](https://github.com/Karnak19/openapi-codegen/commit/f05ab09dfb451061ff234629206362293743bea9))
+* JSDoc generation ([#92](https://github.com/Karnak19/openapi-codegen/issues/92)) ([2dcfa87](https://github.com/Karnak19/openapi-codegen/commit/2dcfa87fa6285ba8e2b8963eb24e542e9f0d6f91))
+* omit `initialData` to support tanstack-query v5 ([35a28b5](https://github.com/Karnak19/openapi-codegen/commit/35a28b5047ee4ee7e4c0975dec0060d831585a58))
+* Parse dot case in path params ([#201](https://github.com/Karnak19/openapi-codegen/issues/201)) ([84b7928](https://github.com/Karnak19/openapi-codegen/commit/84b79284ee832070b08138e5585873124ce30150)), closes [#101](https://github.com/Karnak19/openapi-codegen/issues/101)
+* permit `null` as body ([bdfa4b9](https://github.com/Karnak19/openapi-codegen/commit/bdfa4b9a6062b0b9ddd23f589d0d7acd88589961))
+* remove spaces in fetcher template ([58f7741](https://github.com/Karnak19/openapi-codegen/commit/58f774161856afa9bc16eaba299114ce7de03833))
+* Support for nullable enums ([#146](https://github.com/Karnak19/openapi-codegen/issues/146)) ([151d47a](https://github.com/Karnak19/openapi-codegen/commit/151d47af08d43c8a0c94a244df8da3c4c40e6cd5))
+
 ## [8.0.0](https://github.com/fabien0102/openapi-codegen/compare/typescript-v7.0.1...typescript-v8.0.0) (2023-11-01)
 
 

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -25,7 +25,7 @@
     "plugin",
     "typescript"
   ],
-  "author": "Fabien Bernard",
+  "author": "Basile Vernouillet",
   "license": "MIT",
   "dependencies": {
     "case": "^1.6.3",

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karnak19/openapi-codegen-typescript",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "OpenAPI Codegen typescript generators",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openapi-codegen/typescript",
+  "name": "@karnak19/openapi-codegen-typescript",
   "version": "8.0.0",
   "description": "OpenAPI Codegen typescript generators",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {
-    "url": "https://github.com/fabien0102/openapi-codegen",
+    "url": "https://github.com/karnak19/openapi-codegen",
     "directory": "plugins/typescript"
   },
   "publishConfig": {


### PR DESCRIPTION
For some reason, the Prettier version on the `cli` package is `2.8.8`

https://npmgraph.js.org/?q=@openapi-codegen/cli#select=exact%3Aprettier%402.8.8

Maybe just a new build is needed, but why not bump to latest version too