### PR TITLE
fix: Update prettier version to 3.2.5

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -46,7 +46,7 @@
     "ink": "^3.2.0",
     "js-yaml": "^4.1.0",
     "openapi3-ts": "^2.0.1",
-    "prettier": "^3.0.3",
+    "prettier": "^3.2.5",
     "rxjs": "^7.5.4",
     "slash": "^4.0.0",
     "swagger2openapi": "^7.0.8",

--- a/cli/src/commands/GenerateCommand.ts
+++ b/cli/src/commands/GenerateCommand.ts
@@ -233,9 +233,14 @@ export class GenerateCommand extends Command {
     const prettierConfig = await prettier.resolveConfig(process.cwd());
 
     const writeFile = async (file: string, data: string) => {
+      const updatedConfig = await prettier.format(data, {
+        parser: "babel-ts",
+        ...prettierConfig,
+      });
+
       await fsExtra.outputFile(
         path.join(process.cwd(), config.outputDir, file),
-        prettier.format(data, { parser: "babel-ts", ...prettierConfig })
+        updatedConfig
       );
     };
 

--- a/cli/src/commands/InitCommand.ts
+++ b/cli/src/commands/InitCommand.ts
@@ -140,8 +140,8 @@ export class InitCommand extends Command {
       source === "file"
         ? await this.askForFile()
         : source === "url"
-        ? await this.askForUrl()
-        : await this.prompt.github("todo: inject the token");
+          ? await this.askForUrl()
+          : await this.prompt.github("todo: inject the token");
 
     const namespace = format.camel(
       await this.prompt.input({
@@ -188,7 +188,7 @@ export class InitCommand extends Command {
 
     const prettierConfig = await prettier.resolveConfig(process.cwd());
 
-    const updatedConfig = prettier.format(
+    const updatedConfig = await prettier.format(
       printer.printFile(updatedConfigSourceFile),
       { parser: "babel-ts", ...prettierConfig }
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "husky": "^7.0.2",
         "jest": "^27.2.5",
         "lerna": "^5.5.0",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "pretty-quick": "^3.1.1",
         "typescript": "4.8.2"
       },
@@ -50,7 +50,7 @@
         "ink": "^3.2.0",
         "js-yaml": "^4.1.0",
         "openapi3-ts": "^2.0.1",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "rxjs": "^7.5.4",
         "slash": "^4.0.0",
         "swagger2openapi": "^7.0.8",
@@ -14121,9 +14121,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20687,7 +20687,7 @@
         "js-yaml": "^4.1.0",
         "nock": "^13.2.1",
         "openapi3-ts": "^2.0.1",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "react": "^17.0.2",
         "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-internal": "^1.0.4",
@@ -28168,9 +28168,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "husky": "^7.0.2",
     "jest": "^27.2.5",
     "lerna": "^5.5.0",
-    "prettier": "^3.0.3",
+    "prettier": "^3.2.5",
     "pretty-quick": "^3.1.1",
     "typescript": "4.8.2"
   },


### PR DESCRIPTION
For some reason, the Prettier version on the cli package is 2.8.8

https://npmgraph.js.org/?q=@openapi-codegen/cli#select=exact%3Aprettier%402.8.8

This PR updated it to current latest