### PR TITLE
fix: Changed Read API Method for Github from Graphql API to Rest API

### DIFF
--- a/cli/src/core/getOpenAPISourceFile.ts
+++ b/cli/src/core/getOpenAPISourceFile.ts
@@ -70,7 +70,7 @@ export const getOpenAPISourceFile = async (
         prompt.close();
 
         if (!raw.content) {
-          throw new UsageError("Content is empty");
+          throw new UsageError(`No content found at "${options.specPath}"`);
         }
 
         const encoding: BufferEncoding =


### PR DESCRIPTION
As github graphql has body size limitation due to which large spec files gets trim and validation fails the generation so switched the reading of file form github graphql api to rest api as it doesn't have the same limitation of content reading 

This PR resolve this [issue](https://github.com/fabien0102/openapi-codegen/issues/251)