### PR TITLE
fix: properly handle request errors

### DIFF
--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -109,11 +109,8 @@ export async function ${camel(prefix)}Fetch<
               : "Unexpected error"
         };
       }
-
-      throw error;
     }
-
-    if (response.headers.get('content-type')?.includes('json')) {
+    else if (response.headers.get('content-type')?.includes('json')) {
       return await response.json();
     } else {
       // if it is not a json response, assume it is a blob and cast it to TData
@@ -128,6 +125,7 @@ export async function ${camel(prefix)}Fetch<
     };
     throw errorObject;
   }
+  throw error;
 }
 
 const resolveUrl = (


### PR DESCRIPTION
Currently when a request goes wrong (essentially when `!response.ok`) we always end up with some sort of `Network Error`, which is not the desired behavior when the spec and the generated typing expects us to have a `<RequestSecifc>Error`.

As this issue isn't new and has been solved in comments by [SeanCondon](https://github.com/SeanCondon) as well as [MarcusOhman91](https://github.com/MarcusOhman91) already this is more of a paperwork PR.

Closes #188
Closes #113