### PR TITLE
fix(cli): update rollup config

### DIFF
--- a/cli/rollup.config.js
+++ b/cli/rollup.config.js
@@ -9,7 +9,7 @@ import typescript from "@rollup/plugin-typescript";
 const typescriptPlugin = typescript({
   tsconfig: "./tsconfig.package.json",
   compilerOptions: {
-    outDir: ".",
+    outDir: "lib",
     sourceMap: false,
   },
 });
@@ -18,7 +18,7 @@ export default [
   {
     input: "src/index.ts",
     output: {
-      file: "lib/index.js",
+      dir: "lib",
       format: "es",
     },
     cache: false,
@@ -27,7 +27,7 @@ export default [
   {
     input: "src/cli.ts",
     output: {
-      file: "lib/cli.js",
+      dir: "lib",
       format: "es",
       banner: "#!/usr/bin/env node",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "cli": {
       "name": "@openapi-codegen/cli",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.5.10",
@@ -20451,7 +20451,7 @@
     },
     "plugins/typescript": {
       "name": "@openapi-codegen/typescript",
-      "version": "8.0.2",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "case": "^1.6.3",


### PR DESCRIPTION
Addresses [issue#264](https://github.com/fabien0102/openapi-codegen/issues/264).

Changes to `package-lock.json` are just the versions of "@openapi-codegen/cli" to "2.0.3" and "@openapi-codegen/typescript" to "8.1.0", result of running "npm i". 