### PR TITLE
fix: Deal with forbidden chars in description

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
@@ -176,6 +176,64 @@ describe("schemaToTypeAliasDeclaration", () => {
     `);
   });
 
+  it("should pick the first line of the description if the body contains */", () => {
+    const schema: SchemaObject = {
+      title: "Deployment branch policy name pattern",
+      required: ["name"],
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: `The name pattern that branches must match in order to deploy to the environment.
+
+            Wildcard characters will not match \`/\`. For example, to match branches that begin with \`release/\` and contain an additional single slash, use \`release/*/*\`.
+            For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).`,
+          example: "release/*",
+        },
+      },
+    };
+
+    expect(printSchema(schema)).toMatchInlineSnapshot(`
+     "export type Test = {
+         /**
+          * The name pattern that branches must match in order to deploy to the environment.
+          *
+          * [see original specs]
+          *
+          * @example release/*
+          */
+         name: string;
+     };"
+    `);
+  });
+
+  it("should skip the description if the first line contains */", () => {
+    const schema: SchemaObject = {
+      title: "Deployment branch policy name pattern",
+      required: ["name"],
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: `Wildcard characters will not match \`/\`. For example, to match branches that begin with \`release/\` and contain an additional single slash, use \`release/*/*\`.
+            For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).`,
+          example: "release/*",
+        },
+      },
+    };
+
+    expect(printSchema(schema)).toMatchInlineSnapshot(`
+     "export type Test = {
+         /**
+          * [see original specs]
+          *
+          * @example release/*
+          */
+         name: string;
+     };"
+    `);
+  });
+
   it("should generate top-level documentation", () => {
     const schema: SchemaObject = {
       type: "null",


### PR DESCRIPTION
When a description includes `*/`, this is causing a broken generated multiline comment, let’s strip them in a smart way to avoid this issue.

Example in github specs:

```yaml
deployment-branch-policy-name-pattern:
      properties:
        name:
          description: |-
            The name pattern that branches must match in order to deploy to the environment.

            Wildcard characters will not match `/`. For example, to match branches that begin with `release/` and contain an additional single slash, use `release/*/*`.
            For more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).
          example: release/*
          type: string
      required:
        - name
      title: Deployment branch policy name pattern
      type: object

```

The `release/*/*` will close the generated comment and produce a broken javascript