### PR TITLE
fix: Invalid variable access inside fetcher

### DIFF
--- a/plugins/typescript/src/templates/fetcher.ts
+++ b/plugins/typescript/src/templates/fetcher.ts
@@ -72,6 +72,7 @@ export async function ${camel(prefix)}Fetch<
   TQueryParams,
   TPathParams
 >): Promise<TData> {
+  let error: ErrorWrapper<TError>;
   try {
     const requestHeaders: HeadersInit = {
       "Content-Type": "application/json",
@@ -97,7 +98,6 @@ export async function ${camel(prefix)}Fetch<
       }
     );
     if (!response.ok) {
-      let error: ErrorWrapper<TError>;
       try {
         error = await response.json();
       } catch (e) {


### PR DESCRIPTION
Fixes an error introduced by #260

Error variable was still initialized inside the try-catch block but throw was moved outside.

I just moved the initialization to the top of the function similar to #188 