### PR TITLE
fix: Escape special chars in enum name

### DIFF
--- a/plugins/typescript/src/core/schemaToEnumDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToEnumDeclaration.test.ts
@@ -71,14 +71,20 @@ describe("schemaToTypeAliasDeclaration", () => {
   it("should generate valid enum with values that contains spaces", () => {
     const schema: SchemaObject = {
       type: "string",
-      enum: ["saimois", "bengal", "british shorthair"],
+      enum: [
+        "saimois",
+        "bengal",
+        "british shorthair",
+        "danish\u2013swedish farmdog",
+      ],
     };
 
     expect(printSchema(schema, "test")).toMatchInlineSnapshot(`
       "export enum Test {
           Saimois = "saimois",
           Bengal = "bengal",
-          BritishShorthair = "british shorthair"
+          BritishShorthair = "british shorthair",
+          "danish\\u2013swedish farmdog" = "danish\\u2013swedish farmdog"
       }"
     `);
   });

--- a/plugins/typescript/src/core/schemaToEnumDeclaration.ts
+++ b/plugins/typescript/src/core/schemaToEnumDeclaration.ts
@@ -5,6 +5,30 @@ import { convertNumberToWord } from "../utils/getEnumProperties";
 import { Context, getJSDocComment } from "./schemaToTypeAliasDeclaration";
 
 /**
+ * Function to check if a string is a valid TypeScript identifier
+ *
+ * @param name Name to check
+ */
+function isValidIdentifier(name: string): boolean {
+  if (name.length === 0) {
+    return false;
+  }
+
+  const firstChar = name.charCodeAt(0);
+  if (!ts.isIdentifierStart(firstChar, ts.ScriptTarget.Latest)) {
+    return false;
+  }
+
+  for (let i = 1; i < name.length; i++) {
+    if (!ts.isIdentifierPart(name.charCodeAt(i), ts.ScriptTarget.Latest)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Add Enum support when transforming an OpenAPI Schema Object to Typescript Nodes.
  *
  * @param name Name of the schema
@@ -52,8 +76,11 @@ function getEnumMembers(schema: SchemaObject): ts.EnumMember[] {
       throw new Error(`Unsupported enum value type: ${typeof enumValue}`);
     }
 
+    enumName = pascal(enumName);
     return f.createEnumMember(
-      f.createIdentifier(pascal(enumName)),
+      isValidIdentifier(enumName)
+        ? f.createIdentifier(enumName)
+        : f.createStringLiteral(`${enumValue}`),
       enumValueNode
     );
   });


### PR DESCRIPTION
Similar to #207 however addressing the issue more generally.

Enum names could contain characters that are not allowed to be used as identifiers. The best example is a string starting with a number, however it could also be like in the example "danish–swedish farmdog" a string using `–` which is `\u2013`.

As several issues are already solved by using `pascal` (` ` and `-`) it acts as a last resort if even this fails.