### PR TITLE
fix: Deal with empty object generation

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
@@ -483,6 +483,17 @@ describe("schemaToTypeAliasDeclaration", () => {
     `);
   });
 
+  it("should generate an empty object", () => {
+    const schema: SchemaObject = {
+      type: "object",
+      additionalProperties: false,
+    };
+
+    expect(printSchema(schema)).toMatchInlineSnapshot(
+      `"export type Test = Record<string, never>;"`
+    );
+  });
+
   it("should generate an object with additional properties", () => {
     const schema: SchemaObject = {
       type: "object",

--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.ts
@@ -223,14 +223,15 @@ export const getType = (
         return withNullable(f.createTypeLiteralNode([]), schema.nullable);
       }
 
-      if (
-        !schema.properties /* free form object */ &&
-        !schema.additionalProperties
-      ) {
+      if (!schema.properties && !schema.additionalProperties) {
         return withNullable(
           f.createTypeReferenceNode(f.createIdentifier("Record"), [
             f.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-            f.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+            f.createKeywordTypeNode(
+              schema.additionalProperties === false
+                ? ts.SyntaxKind.NeverKeyword // empty object
+                : ts.SyntaxKind.AnyKeyword // free form object
+            ),
           ]),
           schema.nullable
         );


### PR DESCRIPTION
`{type: "object", additionalProperties: false}` should generate `Record<string, never>` instead of `Record<string, any>` (free form object vs empty object)

Closed #258