### PR TITLE
feat: handle large specs

### DIFF
--- a/cli/src/core/getOpenAPISourceFile.ts
+++ b/cli/src/core/getOpenAPISourceFile.ts
@@ -58,32 +58,23 @@ export const getOpenAPISourceFile = async (
           `https://api.github.com/repos/${options.owner}/${options.repository}/contents/${options.specPath}?ref=${options.ref}`,
           {
             headers: {
-              "content-type": "application/json",
+              accept: "application/vnd.github.raw+json",
               "user-agent": "openapi-codegen",
               authorization: `bearer ${token}`,
             },
           }
-        ).json<{
-          content: string;
-          encoding: string | null;
-        }>();
+        ).text();
 
-        if (!raw.content) {
+        if (!raw) {
           throw new UsageError(`No content found at "${options.specPath}"`);
         }
-
-        const encoding: BufferEncoding =
-          (raw.encoding as BufferEncoding) || "base64";
-        const textContent = Buffer.from(raw.content, encoding).toString(
-          "utf-8"
-        );
 
         let format: OpenAPISourceFile["format"] = "yaml";
         if (options.specPath.toLowerCase().endsWith("json")) {
           format = "json";
         }
 
-        return { text: textContent, format };
+        return { text: raw, format };
       } catch (e) {
         if (
           e instanceof HTTPError &&


### PR DESCRIPTION
## Problem
Github strips large file, we need to use the `raw` media type to avoid this issue

## References
From github specs

https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
> If the requested file's size is:
> * 1 MB or smaller: All features of this endpoint are supported.
> * Between 1-100 MB: Only the raw or object custom media types are supported. Both will work as normal, except that when > using the object media type, the content field will be an empty string and the encoding field will be "none". To get the contents of these larger files, use the raw media type.
> * Greater than 100 MB: This endpoint is not supported.
