### PR TITLE
doc: Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 
 ### React Query components
 
-Using [https://api.apis.guru/v2/specs/giphy.com/1.0/openapi.yaml](giphy specs) as example
+Using [giphy specs](https://api.apis.guru/v2/specs/giphy.com/1.0/openapi.yaml) as example
 
 This will generate lot of ready-to-use hooks like:
 


### PR DESCRIPTION
A tiny fix for a tiny typo 😉

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/cd5d2946-8cd3-43f0-8c8d-ce5a7b44a6e3) | ![after](https://github.com/user-attachments/assets/33f7c8e9-12dc-4c17-a57d-72875453da9d) |
