### PR TITLE
chore: Add support for refs with property path

### DIFF
--- a/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
+++ b/plugins/typescript/src/core/schemaToTypeAliasDeclaration.test.ts
@@ -89,6 +89,49 @@ describe("schemaToTypeAliasDeclaration", () => {
     `);
   });
 
+  it("should resolve ref in object properties to deep linking", () => {
+    const schema: SchemaObject = {
+      type: "object",
+      properties: {
+        age: { $ref: "#/components/schemas/Age/properties/age" },
+        breed: { $ref: "#/components/schemas/Breeds/items/properties/name" },
+        color: {
+          $ref: "#/components/schemas/Breeds/items/properties/color/items",
+        },
+      },
+      required: ["age", "breed"],
+    };
+
+    expect(
+      printSchema(schema, "Dog", "schemas", {
+        schemas: {
+          Breeds: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                color: { type: "array", items: { type: "string" } },
+              },
+            },
+          },
+          Age: {
+            type: "object",
+            properties: {
+              age: { type: "integer" },
+            },
+          },
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "export type Dog = {
+          age: Age["age"];
+          breed: Breeds[number]["name"];
+          color?: Breeds[number]["color"][number];
+      };"
+    `);
+  });
+
   it("should generate enums (strings)", () => {
     const schema: SchemaObject = {
       type: "string",


### PR DESCRIPTION
Addressing the issue mentioned in #308 with $ref paths that refer to a specific property inside the referenced object.

For now added support for $ref paths that contain `items` and `properties/propName`. The implementation loops over the property path and:

* maps `properties/propName` to `["propName"]`
* maps `items` to `[number]`
* or skips the part of the path if both cases do not apply