### PR TITLE
doc: Update links to React Query in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,8 @@
 
    If during generator setup you picked `> React Query components`, then you will need to install and configure React Query in order for the generated React hooks to work properly:
 
-   - Install the library
-
-     ```bash
-     npm i @tanstack/react-query
-     ```
-
-   - Wire up the `QueryClient` as described [here](https://tanstack.com/query/v4/docs/adapters/react-query).
+   - [Install the React Query library](https://tanstack.com/query/latest/docs/framework/react/installation)
+   - [Wire up the QueryClientProvider component](https://tanstack.com/query/latest/docs/framework/react/reference/QueryClientProvider) to connect and provide a QueryClient to your application
 
 ## Usage
 


### PR DESCRIPTION
Tanstack has somewhat recently rearranged their documentation, causing some old pages to 404. This addresses that, as well as drops in a link to the React Query lib install page, which covers different options for installing depending on project setup.

README change from this:
<img width="831" alt="SCR-20250428-hkza" src="https://github.com/user-attachments/assets/2d5e6635-5c76-4989-acac-05f72e7d5fcd" />

To this:
<img width="837" alt="SCR-20250428-hlbs" src="https://github.com/user-attachments/assets/a72d570c-ad35-4cb2-97ae-2db4e264209d" />
