### PR TITLE
feat: Generate named response types for oneOf union responses

### DIFF
--- a/plugins/typescript/src/core/getOperationTypes.ts
+++ b/plugins/typescript/src/core/getOperationTypes.ts
@@ -242,5 +242,6 @@ export const getOperationTypes = ({
  */
 const shouldExtractNode = (node: ts.Node) =>
   ts.isIntersectionTypeNode(node) ||
+  ts.isUnionTypeNode(node) ||
   (ts.isTypeLiteralNode(node) && node.members.length > 0) ||
   ts.isArrayTypeNode(node);


### PR DESCRIPTION
### Problem
When OpenAPI specifications use `oneOf` in response schemas, the TypeScript codegen creates union types but fails to generate the corresponding `{operationId}Response` type aliases. This inconsistency makes it difficult to use these response types in API mocking libraries and other tooling that rely on consistent named types.

### Solution
Extended the `shouldExtractNode` function to recognize `ts.isUnionTypeNode(node)` as a complex type that should be extracted into a named type alias. This ensures that responses defined with `oneOf` generate proper `{operationId}Response` types, maintaining consistency with other response types.

### Example

**OpenAPI spec with oneOf response:**
```yaml
paths:
  /user/{userId}:
    get:
      operationId: getUser
      parameters:
        - name: userId
          in: path
          required: true
          schema:
            type: string
      responses:
        "200":
          description: User found
          content:
            application/json:
              schema:
                oneOf:
                  - $ref: '#/components/schemas/User'
                  - $ref: '#/components/schemas/AdminUser'
```

**Before:** Only inline union type generated  
```ts
export type GetUserPathParams = {
  userId: string;
};

export type GetUserError = Fetcher.ErrorWrapper<undefined>;

export type GetUserVariables = {
  pathParams: GetUserPathParams;
} & GithubContext["fetcherOptions"];

export const fetchGetUser = (
  variables: GetUserVariables,
  signal?: AbortSignal
) =>
  githubFetch<
    Schemas.User | Schemas.AdminUser,
    GetUserError,
    undefined,
    {},
    {},
    GetUserPathParams
  >({ url: "/user/{userId}", method: "get", ...variables, signal });
```


**After:** `GetUserResponse` type alias generated

```ts
export type GetUserPathParams = {
  userId: string;
};

export type GetUserError = Fetcher.ErrorWrapper<undefined>;

export type GetUserResponse = Schemas.User | Schemas.AdminUser;

export type GetUserVariables = {
  pathParams: GetUserPathParams;
} & GithubContext["fetcherOptions"];

export const fetchGetUser = (
  variables: GetUserVariables,
  signal?: AbortSignal
) =>
  githubFetch<
    GetUserResponse,
    GetUserError,
    undefined,
    {},
    {},
    GetUserPathParams
  >({ url: "/user/{userId}", method: "get", ...variables, signal });
```


This change ensures that developers can consistently reference response types in their API mocking and testing code, regardless of whether the OpenAPI specification uses simple schemas or `oneOf` union types.