### PR TITLE
fix(typescript): derive context `enabled` type from `UseQueryOptions`

### DIFF
--- a/examples/frontend/src/github/githubContext.ts
+++ b/examples/frontend/src/github/githubContext.ts
@@ -1,7 +1,6 @@
 import {
   skipToken,
   type DefaultError,
-  type Enabled,
   type QueryKey,
   type UseQueryOptions,
 } from "@tanstack/react-query";
@@ -31,7 +30,12 @@ export type GithubContext<
      * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
      * Defaults to `true`.
      */
-    enabled?: Enabled<TQueryFnData, TError, TQueryFnData, TQueryKey>;
+    enabled?: UseQueryOptions<
+      TQueryFnData,
+      TError,
+      TQueryFnData,
+      TQueryKey
+    >["enabled"];
   };
 };
 

--- a/plugins/typescript/src/templates/context.ts
+++ b/plugins/typescript/src/templates/context.ts
@@ -8,7 +8,6 @@ export const getContext = (
   `import {
     skipToken,
     type DefaultError,
-    type Enabled,
     type QueryKey,
     type UseQueryOptions,
  } from "@tanstack/react-query";
@@ -35,7 +34,7 @@ export const getContext = (
        * Set this to \`false\` to disable automatic refetching when the query mounts or changes query keys.
        * Defaults to \`true\`.
        */
-      enabled?: Enabled<TQueryFnData, TError, TQueryFnData, TQueryKey>;
+      enabled?: UseQueryOptions<TQueryFnData, TError, TQueryFnData, TQueryKey>['enabled'];
     };
   };
   


### PR DESCRIPTION
## Problem

The React-Query context template hardcodes the exported react-query type name `Enabled`:

`plugins/typescript/src/templates/context.ts`
```ts
import { /* ... */ type Enabled /* ... */ } from '@tanstack/react-query';
// ...
enabled?: Enabled<TQueryFnData, TError, TQueryFnData, TQueryKey>;
```

TanStack Query **[renamed this exported type `Enabled` → `QueryBooleanOption` in v5.100.0](https://github.com/TanStack/query/pull/10515)**. The underlying definition is unchanged — it's purely a rename of the exported alias:

```ts
boolean | ((query: Query<TQueryFnData, TError, TData, TQueryKey>) => boolean)
```

| `@tanstack/react-query` | exported type |
| --- | --- |
| ≤ 5.99.x | `Enabled` |
| ≥ 5.100.0 | `QueryBooleanOption` |

As a result, the generated context file fails to type-check for anyone on react-query ≥ 5.100.0, because `Enabled` no longer exists.

## Why not just rename to `QueryBooleanOption`?

A straight swap would simply move the breakage: it fixes ≥ 5.100.0 consumers but breaks everyone on < 5.100.0, where `QueryBooleanOption` doesn't exist. Since the package declares no react-query peer range, nothing enforces a minimum version, so a hardcoded alias name is fragile in either direction — and this could recur on the next rename.

## Fix

Derive the field structurally from `UseQueryOptions` (already imported in this template) instead of referencing the alias name at all:

```ts
enabled?: UseQueryOptions<TQueryFnData, TError, TQueryFnData, TQueryKey>['enabled'];
```

This resolves to whatever react-query types `enabled` as, across every v5 version, and is immune to future renames of the alias. The `type Enabled` import is removed.

## Changes
- `plugins/typescript/src/templates/context.ts`: drop the `Enabled` import; type the `enabled` field via `UseQueryOptions<...>['enabled']`.
- `examples/frontend/src/github/githubContext.ts`: regenerated snapshot (the only generated diff is the `enabled?:` line + dropped import).

## Testing
- `@openapi-codegen/typescript` suite: 229 tests pass.
- Verified the generated context file type-checks against both `@tanstack/react-query@5.66.0` (pre-rename) and `@tanstack/react-query@5.101.2` (post-rename, confirming `Enabled` is gone there yet the structural form still compiles).
